### PR TITLE
Remove netty from jboss-as7.0 assembly since it's already been provided by AS7

### DIFF
--- a/jbpm-console-ng-distribution-wars/src/main/assembly/assembly-showcase-jboss-as-7_0.xml
+++ b/jbpm-console-ng-distribution-wars/src/main/assembly/assembly-showcase-jboss-as-7_0.xml
@@ -98,6 +98,8 @@
           <exclude>WEB-INF/lib/javax*.jar</exclude>
           <exclude>WEB-INF/lib/jboss-interceptors-api*.jar</exclude>
           <exclude>WEB-INF/lib/jaxrs-api-*.jar</exclude>
+          <!--Netty-->
+          <exclude>WEB-INF/lib/netty-3*.jar</exclude>
          
         </excludes>
       </unpackOptions>


### PR DESCRIPTION
If not removing this jar, there is deployment error when deploy designer.war and other console into EAP6.1 at the same time.
