### PR TITLE
Fix equals() in Day -> fixes the issue with displaying tasks for some months

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-api/src/main/java/org/jbpm/console/ng/ht/model/Day.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-api/src/main/java/org/jbpm/console/ng/ht/model/Day.java
@@ -44,6 +44,7 @@ public class Day implements Serializable {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Date needed by GWT
     public boolean equals(Object other) {
         if (this == other)
             return true;
@@ -51,13 +52,16 @@ public class Day implements Serializable {
             return false;
         if (!(other instanceof Day))
             return false;
-        Day otherDay = (Day) other;
-        return this.dayOfWeekName.equals(otherDay.dayOfWeekName);
+        Date otherDate = ((Day) other).getDate();
+        return date.getDate() == otherDate.getDate() &&
+                date.getMonth() == otherDate.getMonth() &&
+                date.getYear() == otherDate.getYear();
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Date needed by GWT
     public int hashCode() {
-        return dayOfWeekName.hashCode();
+        return 31 + 31 * date.getDate() + 31 * date.getMonth() + 31 * date.getYear();
     }
 
 }

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/test/java/org/jbpm/console/ng/ht/backend/server/TaskServiceEntryPointBaseTest.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/test/java/org/jbpm/console/ng/ht/backend/server/TaskServiceEntryPointBaseTest.java
@@ -23,6 +23,18 @@ public abstract class TaskServiceEntryPointBaseTest extends HumanTasksBackendBas
     private static String DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
 
     @Test
+    public void testGetTasksForLongPeriod() {
+        Map<Day, List<TaskSummary>> tasksByDays = consoleTaskService.getTasksOwnedFromDateToDateByDays("Bobba Fet",
+                getTaskStatuses(), createDate("2014-02-24"), 42, "en-UK");
+        assertEquals(42, tasksByDays.size());
+
+        tasksByDays = consoleTaskService.getTasksOwnedFromDateToDateByDays("Bobba Fet",
+                getTaskStatuses(), createDate("2014-02-24"), 3000, "en-UK");
+        assertEquals(3000, tasksByDays.size());
+
+    }
+
+    @Test
     public void testGetTasksOwnedFromDateToDateByDaysNoTasksAtAll() {
         Map<Day, List<TaskSummary>> tasksByDays = consoleTaskService.getTasksOwnedFromDateToDateByDays("Bobba Fet",
                 getTaskStatuses(), createDate("2013-04-18"), 3, "en-UK");


### PR DESCRIPTION
Fixes the issue for e.g. March 2014. Problem was that the Day class changed its purpose and structure from the initial and the equals() method did not get updated. 

Also added simple test into backend to ensure that correct number of days is returned from query even for large date ranges. 
