### PR TITLE
Fix calendar view for Octobers

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/TaskServiceEntryPointImpl.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/TaskServiceEntryPointImpl.java
@@ -38,7 +38,6 @@ import org.jbpm.services.task.impl.model.CommentImpl;
 import org.jbpm.services.task.impl.model.UserImpl;
 import org.jbpm.services.task.utils.ContentMarshallerHelper;
 import org.joda.time.DateTimeConstants;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
 import org.kie.api.task.model.Content;
@@ -203,9 +202,9 @@ public class TaskServiceEntryPointImpl implements TaskServiceEntryPoint {
     @Override
     public Map<Day, List<TaskSummary>> getTasksAssignedAsPotentialOwnerFromDateToDateByDays(String userId,
             List<String> strStatuses, Date from, int nrOfDaysTotal, String language) {
-        long plusDays = (nrOfDaysTotal - 1) * (long) DateTimeConstants.MILLIS_PER_DAY;
+        Date toDate = getEndDateBasedOnStartDateAndNumberOfDaysBetweenThem(from, nrOfDaysTotal);
         return getTasksAssignedAsPotentialOwnerFromDateToDateByDays(userId, strStatuses, from,
-                new Date(from.getTime() + plusDays), language);
+                toDate, language);
     }
 
     public Map<Day, List<TaskSummary>> getTasksAssignedAsPotentialOwnerFromDateToDateByDays(String userId,
@@ -229,9 +228,13 @@ public class TaskServiceEntryPointImpl implements TaskServiceEntryPoint {
     @Override
     public Map<Day, List<TaskSummary>> getTasksOwnedFromDateToDateByDays(String userId, List<String> strStatuses, Date from,
             int nrOfDaysTotal, String language) {
-        long plusDays = (nrOfDaysTotal - 1) * (long) DateTimeConstants.MILLIS_PER_DAY;
-        return getTasksOwnedFromDateToDateByDays(userId, strStatuses, from, new Date(from.getTime() + plusDays),
+        Date toDate = getEndDateBasedOnStartDateAndNumberOfDaysBetweenThem(from, nrOfDaysTotal);
+        return getTasksOwnedFromDateToDateByDays(userId, strStatuses, from, toDate,
                 language);
+    }
+
+    private Date getEndDateBasedOnStartDateAndNumberOfDaysBetweenThem(Date from, int nrOfDaysTotal) {
+        return new LocalDate(from.getTime()).plusDays(nrOfDaysTotal - 1).toDateMidnight().toDate();
     }
 
 
@@ -272,7 +275,7 @@ public class TaskServiceEntryPointImpl implements TaskServiceEntryPoint {
         taskService.start(taskId, userId);
         return taskId;
     }
-    
+
     @Override
     public long addTaskAndClaimAndStart(String taskString, Map<String, Object> inputs, String userId,
             Map<String, Object> templateVars) {

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/test/java/org/jbpm/console/ng/ht/backend/server/TaskServiceEntryPointBaseTest.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/test/java/org/jbpm/console/ng/ht/backend/server/TaskServiceEntryPointBaseTest.java
@@ -32,6 +32,9 @@ public abstract class TaskServiceEntryPointBaseTest extends HumanTasksBackendBas
                 getTaskStatuses(), createDate("2014-02-24"), 3000, "en-UK");
         assertEquals(3000, tasksByDays.size());
 
+        tasksByDays = consoleTaskService.getTasksOwnedFromDateToDateByDays("Bobba Fet",
+                getTaskStatuses(), createDate("2013-09-30"), 35, "en-UK");
+        assertEquals(35, tasksByDays.size());
     }
 
     @Test

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/TasksListPresenter.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/TasksListPresenter.java
@@ -267,7 +267,7 @@ public class TasksListPresenter {
     }
 
     public void refreshPersonalTasks(Date date, TaskView taskView) {
-        DateRange dateRangeToShow = determineFirstDateForTaskViewBasedOnSpecifiedDate(date, taskView);
+        DateRange dateRangeToShow = determineDateRangeForTaskViewBasedOnSpecifiedDate(date, taskView);
         Date fromDate = dateRangeToShow.getStartDate();
         int daysTotal = dateRangeToShow.getDaysInBetween() + 1;
 
@@ -296,7 +296,7 @@ public class TasksListPresenter {
         }
     }
 
-    private DateRange determineFirstDateForTaskViewBasedOnSpecifiedDate(Date date, TaskView taskView) {
+    private DateRange determineDateRangeForTaskViewBasedOnSpecifiedDate(Date date, TaskView taskView) {
         DateRange dateRange;
         switch (taskView) {
             case DAY:
@@ -309,20 +309,21 @@ public class TasksListPresenter {
                 DateRange monthRange = DateUtils.getMonthDateRange(date);
                 DateRange firstWeekRange = DateUtils.getWeekDateRange(monthRange.getStartDate());
                 DateRange lastWeekRange = DateUtils.getWeekDateRange(monthRange.getEndDate());
-                dateRange = new DateRange(firstWeekRange.getStartDate(),lastWeekRange.getEndDate(), 
-                                            CalendarUtil.getDaysBetween(firstWeekRange.getStartDate(),lastWeekRange.getEndDate()) ); 
+                int daysBetween = CalendarUtil.getDaysBetween(firstWeekRange.getStartDate(), lastWeekRange.getEndDate());
+                dateRange = new DateRange(firstWeekRange.getStartDate(),lastWeekRange.getEndDate(),
+                        daysBetween);
                 break;
             case GRID:
                 dateRange = new DateRange(new Date(date.getTime()), new Date(date.getTime()), 0);
                 break;
             default:
-                throw new IllegalStateException("Unreconginized view type '" + taskView + "'!");
+                throw new IllegalStateException("Unrecognized view type '" + taskView + "'!");
         }
         return dateRange;
     }
 
     public void refreshActiveTasks(Date date, TaskView taskView) {
-        DateRange dateRangeToShow = determineFirstDateForTaskViewBasedOnSpecifiedDate(date, taskView);
+        DateRange dateRangeToShow = determineDateRangeForTaskViewBasedOnSpecifiedDate(date, taskView);
         Date fromDate = dateRangeToShow.getStartDate();
         int daysTotal = dateRangeToShow.getDaysInBetween() + 1;
         
@@ -351,7 +352,7 @@ public class TasksListPresenter {
     }
 
     public void refreshGroupTasks(Date date, TaskView taskView) {
-        DateRange dateRangeToShow = determineFirstDateForTaskViewBasedOnSpecifiedDate(date, taskView);
+        DateRange dateRangeToShow = determineDateRangeForTaskViewBasedOnSpecifiedDate(date, taskView);
         Date fromDate = dateRangeToShow.getStartDate();
         int daysTotal = dateRangeToShow.getDaysInBetween() + 1;
         
@@ -379,7 +380,7 @@ public class TasksListPresenter {
     }
 
     public void refreshAllTasks(Date date, TaskView taskView) {
-        DateRange dateRangeToShow = determineFirstDateForTaskViewBasedOnSpecifiedDate(date, taskView);
+        DateRange dateRangeToShow = determineDateRangeForTaskViewBasedOnSpecifiedDate(date, taskView);
         Date fromDate = dateRangeToShow.getStartDate();
         int daysTotal = dateRangeToShow.getDaysInBetween() + 1;
         


### PR DESCRIPTION
For some reason Octobers had only 34(41) days displayed instead of correct 35(42). Not really sure where the problem was, replacing the ad-hoc date code with joda time methods solved it.
