### PR TITLE
BZ-982543: fix previous/next behaviour for month view

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/util/CalendarPicker.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/util/CalendarPicker.java
@@ -55,7 +55,7 @@ public class CalendarPicker extends Composite implements HasValueChangeHandlers<
     private FlowPanel mainPanel = new FlowPanel();
     private FlowPanel calendarPanel = new FlowPanel();
     private FlowPanel iconPanel = new FlowPanel();
-    
+
     private FlowPanel rightPanel = new FlowPanel();
     private FlowPanel controlsPanel = new FlowPanel();
 
@@ -119,30 +119,36 @@ public class CalendarPicker extends Composite implements HasValueChangeHandlers<
      * @param back flag that indicates if the date should be adjusted to future (+) or back (-)
      */
     private void adjustDate(boolean back) {
-        int dayDiff = 0;
         switch (viewType) {
             case DAY:
-                dayDiff = 1;
+                if (back) {
+                    CalendarUtil.addDaysToDate(currentDate, -1);
+                } else {
+                    CalendarUtil.addDaysToDate(currentDate, 1);
+                }
                 break;
 
             case WEEK:
-                dayDiff = 7;
+                if (back) {
+                    CalendarUtil.addDaysToDate(currentDate, -7);
+                } else {
+                    CalendarUtil.addDaysToDate(currentDate, 7);
+                }
+
                 break;
 
             case MONTH:
-                Date nextMonthSameDate = new Date(currentDate.getTime());
-                CalendarUtil.addMonthsToDate(nextMonthSameDate, 1);
-                dayDiff = CalendarUtil.getDaysBetween(currentDate, nextMonthSameDate);
+                if (back) {
+                    currentDate = DateUtils.getSameOrClosestDateInPreviousMonth(currentDate);
+                } else {
+                    currentDate = DateUtils.getSameOrClosestDateInNextMonth(currentDate);
+                }
+
                 break;
             case GRID:
-                dayDiff = 0;
+                // no date change needed
                 break;
 
-        }
-        if (back) {
-            CalendarUtil.addDaysToDate(currentDate, -dayDiff);
-        } else {
-            CalendarUtil.addDaysToDate(currentDate, dayDiff);
         }
         propagateDateChanges();
     }
@@ -155,7 +161,7 @@ public class CalendarPicker extends Composite implements HasValueChangeHandlers<
 
     /**
      * Updates the label text based on current view type and current date.
-     *
+     * <p/>
      * Examples for day, week and month:
      * <ul>
      * <li>day view: 2013-05-02
@@ -223,7 +229,7 @@ public class CalendarPicker extends Composite implements HasValueChangeHandlers<
                 calendarPanel.add(dateBox);
                 dateBox.show();
                 dateBox.removeFromParent();
-                
+
                 calendarPanel.add(calendarLabel);
             }
         });
@@ -260,7 +266,7 @@ public class CalendarPicker extends Composite implements HasValueChangeHandlers<
     /**
      * Determines if 'today' is within the currently displayed date range (e.g. week or month). If it is, the 'Today' button is
      * disabled, otherwise its enabled.
-     *
+     * <p/>
      * Clicking on "Today" button when current day (today) is already displayed is useless, so its better to disable the button.
      */
     private void updateTodayButtonEnabled() {

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/util/DateUtils.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/util/DateUtils.java
@@ -29,7 +29,6 @@ public class DateUtils {
      * Creates new {@link Date} object using default format - "yyyy-MM-dd" (e.g. 2013-04-25).
      *
      * @param dateString string representation of date
-     *
      * @return new {@link Date} create from string representation
      */
     public static Date createDate(String dateString) {
@@ -99,7 +98,7 @@ public class DateUtils {
         CalendarUtil.addMonthsToDate(endDate, 1);
         CalendarUtil.addDaysToDate(endDate, -1);
         endDate.setHours(0);
-        
+
         return new DateRange(startDate, endDate, CalendarUtil.getDaysBetween(startDate, endDate));
     }
 
@@ -108,7 +107,6 @@ public class DateUtils {
      *
      * @param date the date to test
      * @param dateRange date range to be tested with
-     *
      * @return true if the date is within the range, otherwise false
      */
     public static boolean isDateInRange(Date date, DateRange dateRange) {
@@ -138,11 +136,36 @@ public class DateUtils {
      *
      * @param firstDate first date
      * @param secondDate second date
-     *
      * @return true if the dates have identical year, month and day
      */
     public static boolean areDatesEqual(Date firstDate, Date secondDate) {
         return compareDates(firstDate, secondDate) == 0;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static Date getSameOrClosestDateInPreviousMonth(Date date) {
+        Date desiredDate = new Date(date.getTime());
+        CalendarUtil.addMonthsToDate(desiredDate, -1);
+        if (desiredDate.getMonth() == date.getMonth()) {
+            // did not go one month back
+            // e.g. 31 May -> 1st May, because April does not have 31st and thus the day is set to 1st May
+            CalendarUtil.setToFirstDayOfMonth(desiredDate);
+            CalendarUtil.addDaysToDate(desiredDate, -1);
+        }
+        return desiredDate;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static Date getSameOrClosestDateInNextMonth(Date date) {
+        Date desiredDate = new Date(date.getTime());
+        CalendarUtil.addMonthsToDate(desiredDate, 1);
+        if (desiredDate.getMonth() > date.getMonth() + 1) {
+            // skipped one month, e.g. 30 January -> 2nd (or 1st for leap-year) March, because February does not have 30th
+            // set the date to last day of previous month
+            CalendarUtil.setToFirstDayOfMonth(desiredDate);
+            CalendarUtil.addDaysToDate(desiredDate, -1);
+        }
+        return desiredDate;
     }
 
 }

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/test/java/org/jbpm/console/ng/ht/client/util/GwtTestDateUtils.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/test/java/org/jbpm/console/ng/ht/client/util/GwtTestDateUtils.java
@@ -26,6 +26,11 @@ import com.google.gwt.junit.client.GWTTestCase;
 
 public class GwtTestDateUtils extends GWTTestCase {
 
+    @Override
+    public String getModuleName() {
+        return "org.jbpm.console.ng.ht.JbpmConsoleNGHumanTasksClient";
+    }
+
     @Test
     @SuppressWarnings("deprecation")
     public void testCreateDateWithDefaultFormat() {
@@ -100,17 +105,17 @@ public class GwtTestDateUtils extends GWTTestCase {
     public void testIsDateInRange() {
         // single day in range
         Date date = createDate("2013-05-15");
-        DateRange dateRange = new DateRange(createDate("2013-05-15"), createDate("2013-05-15"),0);
+        DateRange dateRange = new DateRange(createDate("2013-05-15"), createDate("2013-05-15"), 0);
         assertTrue(DateUtils.isDateInRange(date, dateRange));
 
         // start date same as specified
         date = createDate("2013-05-15");
-        dateRange = new DateRange(createDate("2013-05-15"), createDate("2014-05-19"),0);
+        dateRange = new DateRange(createDate("2013-05-15"), createDate("2014-05-19"), 0);
         assertTrue(DateUtils.isDateInRange(date, dateRange));
 
         // end date same as specified
         date = createDate("2013-05-15");
-        dateRange = new DateRange(createDate("2013-05-13"), createDate("2013-05-15"),0);
+        dateRange = new DateRange(createDate("2013-05-13"), createDate("2013-05-15"), 0);
         assertTrue(DateUtils.isDateInRange(date, dateRange));
     }
 
@@ -160,9 +165,45 @@ public class GwtTestDateUtils extends GWTTestCase {
         assertFalse(DateUtils.areDatesEqual(date1, date2));
     }
 
-    @Override
-    public String getModuleName() {
-        return "org.jbpm.console.ng.ht.JbpmConsoleNGHumanTasksClient";
+    @Test
+    public void testGetSameOrClosestDateInPreviousMonth() {
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2013-02-28"), createDate("2013-01-28"));
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2013-06-15"), createDate("2013-05-15"));
+        // corner cases
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2013-03-31"), createDate("2013-02-28"));
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2013-03-30"), createDate("2013-02-28"));
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2013-03-29"), createDate("2013-02-28"));
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2013-05-31"), createDate("2013-04-30"));
+        // leap-year
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2016-03-31"), createDate("2016-02-29"));
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2016-03-30"), createDate("2016-02-29"));
+        getAndAssertSameOrClosestDateInPreviousMonth(createDate("2016-03-29"), createDate("2016-02-29"));
+    }
+
+    @Test
+    public void testGetSameOrClosestDateInNextMonth() {
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-01-12"), createDate("2013-02-12"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-12-01"), createDate("2014-01-01"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-01-28"), createDate("2013-02-28"));
+        // corner cases
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-01-29"), createDate("2013-02-28"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-01-30"), createDate("2013-02-28"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-01-31"), createDate("2013-02-28"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2013-03-31"), createDate("2013-04-30"));
+        // leap-year
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2016-01-29"), createDate("2016-02-29"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2016-01-30"), createDate("2016-02-29"));
+        getAndAssertSameOrClosestDateInNextMonth(createDate("2016-01-31"), createDate("2016-02-29"));
+    }
+
+    private void getAndAssertSameOrClosestDateInNextMonth(Date date, Date expectedDate) {
+        Date resultDate = DateUtils.getSameOrClosestDateInNextMonth(date);
+        assertTrue("Expected " + expectedDate + ", got " + resultDate, DateUtils.areDatesEqual(resultDate, expectedDate));
+    }
+
+    private void getAndAssertSameOrClosestDateInPreviousMonth(Date date, Date expectedDate) {
+        Date resultDate = DateUtils.getSameOrClosestDateInPreviousMonth(date);
+        assertTrue("Expected " + expectedDate + ", got " + resultDate, DateUtils.areDatesEqual(resultDate, expectedDate));
     }
 
 }


### PR DESCRIPTION
Problem was that the CalendarUtil.addMonthsToDate() can sometimes skip month, because the requested day does not exist in the prev/next month. e.g. 29th January -> 1st March: 29th February does not exists, so the next day (1st March) is returned.
