### PR TITLE
Configuration of the popup of creation for users and groups

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewgroup/QuickNewGroupPresenter.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewgroup/QuickNewGroupPresenter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.ht.client.editors.quicknewgroup;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.client.api.RemoteCallback;
+import org.jboss.errai.ioc.client.api.Caller;
+import org.jbpm.console.ng.ht.client.i18n.Constants;
+import org.jbpm.console.ng.ht.model.IdentitySummary;
+import org.jbpm.console.ng.ht.service.GroupServiceEntryPoint;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchPopup;
+import org.uberfire.client.mvp.UberView;
+import org.uberfire.lifecycle.OnOpen;
+import org.uberfire.lifecycle.OnStartup;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.security.Identity;
+import org.uberfire.workbench.events.BeforeClosePlaceEvent;
+
+import com.github.gwtbootstrap.client.ui.TextBox;
+import com.google.gwt.core.client.GWT;
+
+@Dependent
+@WorkbenchPopup(identifier = "Quick New Group")
+public class QuickNewGroupPresenter {
+
+    private static final String GROUP = "Group";
+
+	private Constants constants = GWT.create( Constants.class );
+    
+    @Inject
+    QuickNewGroupView view;
+
+    @Inject
+    Identity identity;
+
+    @Inject
+    Caller<GroupServiceEntryPoint> groupService;
+
+    @Inject
+    private Event<BeforeClosePlaceEvent> closePlaceEvent;
+
+    public interface QuickNewGroupView extends UberView<QuickNewGroupPresenter> {
+
+        void displayNotification( String text );
+        
+        TextBox getDescriptionText();
+
+    }
+
+    private PlaceRequest place;
+
+    @OnStartup
+    public void onStartup( final PlaceRequest place ) {
+        this.place = place;
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return constants.Add_Group();
+    }
+
+    @WorkbenchPartView
+    public UberView<QuickNewGroupPresenter> getView() {
+        return view;
+    }
+
+    public QuickNewGroupPresenter() {
+    }
+
+    @PostConstruct
+    public void init() {
+    }
+
+    
+    @OnOpen
+    public void onOpen() {
+        view.getDescriptionText().setFocus( true );
+    }
+    
+    public void addGroup(  ){
+    	groupService.call( new RemoteCallback<Void>() {
+            @Override
+            public void callback( Void nothing ) {
+                view.displayNotification( "Group Created (id = " + view.getDescriptionText().getText() + ")" );
+                close();
+
+            }
+        } ).save(new IdentitySummary(view.getDescriptionText().getText(), GROUP));
+    }
+
+    public void close() {
+        closePlaceEvent.fire( new BeforeClosePlaceEvent( this.place ) );
+    }
+}

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewgroup/QuickNewGroupViewImpl.html
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewgroup/QuickNewGroupViewImpl.html
@@ -1,0 +1,23 @@
+<div class="container-fluid">
+    <div class="row-fluid">
+        <div class="span12">
+        
+        	
+        	<div class="form-horizontal">
+                <fieldset>
+                    <div class="control-group" data-field="descriptionControlGroup" >
+                    </div>
+                </fieldset>
+            </div>
+        
+            <div class="form-horizontal">
+                <fieldset>
+                    <div class="form-actions">
+                        <button class="btn btn-primary" data-field="addGroupButton" id="addGroupButton"></button>
+                    </div>
+                </fieldset>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewgroup/QuickNewGroupViewImpl.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewgroup/QuickNewGroupViewImpl.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.ht.client.editors.quicknewgroup;
+
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.jbpm.console.ng.ht.client.i18n.Constants;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import com.github.gwtbootstrap.client.ui.Button;
+import com.github.gwtbootstrap.client.ui.ControlGroup;
+import com.github.gwtbootstrap.client.ui.ControlLabel;
+import com.github.gwtbootstrap.client.ui.Controls;
+import com.github.gwtbootstrap.client.ui.HelpInline;
+import com.github.gwtbootstrap.client.ui.TextBox;
+import com.github.gwtbootstrap.client.ui.constants.ControlGroupType;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+
+@Dependent
+@Templated(value = "QuickNewGroupViewImpl.html")
+public class QuickNewGroupViewImpl extends Composite implements QuickNewGroupPresenter.QuickNewGroupView {
+
+	private Constants constants = GWT.create( Constants.class );
+
+    private QuickNewGroupPresenter presenter;
+    
+    @Inject
+    public TextBox descriptionText;
+    
+    @Inject
+    @DataField
+    public Button addGroupButton;
+    
+    @Inject
+    @DataField
+    public ControlGroup descriptionControlGroup;
+    
+    @Inject
+    public HelpInline descriptionHelpLabel;
+    
+    @Inject
+    public ControlLabel groupLabel;
+
+    @Inject
+    private Event<NotificationEvent> notification;
+
+
+    @Override
+    public void init( QuickNewGroupPresenter presenter ) {
+        this.presenter = presenter;
+        initializeHtml();
+    }
+    
+    private void initializeHtml(){
+    	groupLabel.add( new HTMLPanel( constants.Group() ) );
+        
+        Controls descriptionControl = new Controls();
+        descriptionControl.add(descriptionText);
+        descriptionControl.add(descriptionHelpLabel);
+        descriptionControlGroup.add(groupLabel);
+        descriptionControlGroup.add(descriptionControl);
+        
+        addGroupButton.setText( constants.Create() );
+    }
+    
+    @EventHandler("addGroupButton")
+    public void addGroupButton( ClickEvent e ) {
+    	if(!descriptionText.getText().isEmpty()){
+    		addGroup();
+    	}else {
+            descriptionText.setFocus(true);
+            descriptionText.setErrorLabel(descriptionHelpLabel);
+            descriptionControlGroup.setType(ControlGroupType.ERROR);
+            descriptionHelpLabel.setText(constants.Text_Require());
+        }
+    	
+        
+    }
+    
+    private void addGroup(){
+    	presenter.addGroup();
+    }
+    
+    @Override
+    public void displayNotification( String text ) {
+        notification.fire( new NotificationEvent( text ) );
+    }
+
+    @Override
+	public TextBox getDescriptionText() {
+		return descriptionText;
+	}
+
+
+}

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewuser/QuickNewUserPresenter.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewuser/QuickNewUserPresenter.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.ht.client.editors.quicknewuser;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.client.api.RemoteCallback;
+import org.jboss.errai.ioc.client.api.Caller;
+import org.jbpm.console.ng.ht.client.i18n.Constants;
+import org.jbpm.console.ng.ht.model.IdentitySummary;
+import org.jbpm.console.ng.ht.service.GroupServiceEntryPoint;
+import org.jbpm.console.ng.ht.service.UserServiceEntryPoint;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchPopup;
+import org.uberfire.client.mvp.UberView;
+import org.uberfire.lifecycle.OnOpen;
+import org.uberfire.lifecycle.OnStartup;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.security.Identity;
+import org.uberfire.workbench.events.BeforeClosePlaceEvent;
+
+import com.github.gwtbootstrap.client.ui.ListBox;
+import com.github.gwtbootstrap.client.ui.TextBox;
+import com.google.gwt.core.client.GWT;
+
+@Dependent
+@WorkbenchPopup(identifier = "Quick New User")
+public class QuickNewUserPresenter {
+
+    private static final String USER = "User";
+
+    private Constants constants = GWT.create(Constants.class);
+
+    @Inject
+    QuickNewUserView view;
+
+    @Inject
+    Identity identity;
+
+    @Inject
+    Caller<UserServiceEntryPoint> userService;
+
+    @Inject
+    Caller<GroupServiceEntryPoint> groupService;
+
+    @Inject
+    private Event<BeforeClosePlaceEvent> closePlaceEvent;
+
+    public interface QuickNewUserView extends UberView<QuickNewUserPresenter> {
+
+        void displayNotification(String text);
+
+        TextBox getDescriptionText();
+
+        ListBox getGroupsList();
+
+    }
+
+    private PlaceRequest place;
+
+    @OnStartup
+    public void onStartup(final PlaceRequest place) {
+        this.place = place;
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return constants.Add_User();
+    }
+
+    @WorkbenchPartView
+    public UberView<QuickNewUserPresenter> getView() {
+        return view;
+    }
+
+    public QuickNewUserPresenter() {
+    }
+
+    @PostConstruct
+    public void init() {
+    }
+
+    @OnOpen
+    public void onOpen() {
+        view.getDescriptionText().setFocus(true);
+    }
+
+    public void addUser() {
+        IdentitySummary user = new IdentitySummary(view.getDescriptionText().getText(), USER);
+        if (view.getGroupsList().getValue() != null && !view.getGroupsList().getValue().isEmpty()) {
+            user.setIdParent(view.getGroupsList().getValue());
+        }
+        userService.call(new RemoteCallback<Void>() {
+            @Override
+            public void callback(Void nothing) {
+                view.displayNotification("User Created (id = " + view.getDescriptionText().getText() + ")");
+                close();
+
+            }
+        }).save(user);
+    }
+
+    public void loadGroup() {
+        groupService.call(new RemoteCallback<List<IdentitySummary>>() {
+            @Override
+            public void callback(List<IdentitySummary> groups) {
+                if (groups != null && !groups.isEmpty()) {
+                    fillListGroups(groups);
+                }
+
+            }
+        }).getAll();
+    }
+
+    private void fillListGroups(List<IdentitySummary> groups) {
+        for (IdentitySummary group : groups) {
+            view.getGroupsList().addItem(group.getId(), group.getId());
+        }
+    }
+
+    public void close() {
+        closePlaceEvent.fire(new BeforeClosePlaceEvent(this.place));
+    }
+
+}

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewuser/QuickNewUserViewImpl.html
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewuser/QuickNewUserViewImpl.html
@@ -1,0 +1,32 @@
+<div class="container-fluid">
+    <div class="row-fluid">
+        <div class="span12">
+        
+        	
+        	<div class="form-horizontal">
+                <fieldset>
+                    <div class="control-group" data-field="descriptionControlUser" >
+                    </div>
+                    
+                    <div class="control-group">
+                        <label class="control-label" for="groupLabel" data-field="groupLabel"></label>
+                        <div class="controls">
+							<select data-field="groupsList" id="groupsList"></select>
+						</div>
+                    </div>
+                    
+                    
+                </fieldset>
+            </div>
+        
+            <div class="form-horizontal">
+                <fieldset>
+                    <div class="form-actions">
+                        <button class="btn btn-primary" data-field="addUserButton" id="addUserButton"></button>
+                    </div>
+                </fieldset>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewuser/QuickNewUserViewImpl.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/quicknewuser/QuickNewUserViewImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.ht.client.editors.quicknewuser;
+
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.jbpm.console.ng.ht.client.i18n.Constants;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import com.github.gwtbootstrap.client.ui.Button;
+import com.github.gwtbootstrap.client.ui.ControlGroup;
+import com.github.gwtbootstrap.client.ui.ControlLabel;
+import com.github.gwtbootstrap.client.ui.Controls;
+import com.github.gwtbootstrap.client.ui.HelpInline;
+import com.github.gwtbootstrap.client.ui.Label;
+import com.github.gwtbootstrap.client.ui.ListBox;
+import com.github.gwtbootstrap.client.ui.TextBox;
+import com.github.gwtbootstrap.client.ui.constants.ControlGroupType;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+
+@Dependent
+@Templated(value = "QuickNewUserViewImpl.html")
+public class QuickNewUserViewImpl extends Composite implements QuickNewUserPresenter.QuickNewUserView {
+
+	private Constants constants = GWT.create( Constants.class );
+
+    private QuickNewUserPresenter presenter;
+    
+    @Inject
+    public TextBox descriptionText;
+    
+    @Inject
+    @DataField
+    public Button addUserButton;
+    
+    @Inject
+    @DataField
+    public ControlGroup descriptionControlUser;
+    
+    @Inject
+    @DataField
+    public Label groupLabel;
+    
+    @Inject
+    @DataField
+    public ListBox groupsList;
+    
+    @Inject
+    public HelpInline descriptionHelpLabel;
+    
+    @Inject
+    public ControlLabel userLabel;
+
+    @Inject
+    private Event<NotificationEvent> notification;
+
+
+    @Override
+    public void init( QuickNewUserPresenter presenter ) {
+        this.presenter = presenter;
+        initializeHtml();
+    }
+    
+    private void initializeHtml(){
+    	groupLabel.setText(constants.Group());
+    	
+    	userLabel.add( new HTMLPanel( constants.User() ) );
+        
+        Controls descriptionControl = new Controls();
+        descriptionControl.add(descriptionText);
+        descriptionControl.add(descriptionHelpLabel);
+        descriptionControlUser.add(userLabel);
+        descriptionControlUser.add(descriptionControl);
+        
+        addUserButton.setText( constants.Create() );
+        
+        initializeListGroup();
+    }
+    
+    private void initializeListGroup(){
+    	presenter.loadGroup();
+    }
+    
+    @EventHandler("addUserButton")
+    public void addUserButton( ClickEvent e ) {
+    	if(!descriptionText.getText().isEmpty()){
+    		addUser();
+    	}else {
+            descriptionText.setFocus(true);
+            descriptionText.setErrorLabel(descriptionHelpLabel);
+            descriptionControlUser.setType(ControlGroupType.ERROR);
+            descriptionHelpLabel.setText(constants.Text_Require());
+        }
+    	
+        
+    }
+    
+    private void addUser(){
+    	presenter.addUser();
+    }
+    
+    @Override
+    public void displayNotification( String text ) {
+        notification.fire( new NotificationEvent( text ) );
+    }
+
+    @Override
+	public TextBox getDescriptionText() {
+		return descriptionText;
+	}
+
+	@Override
+	public ListBox getGroupsList() {
+		return groupsList;
+	}
+
+
+}

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/i18n/Constants.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/i18n/Constants.java
@@ -140,4 +140,6 @@ public interface Constants extends Messages {
     String Auto_Assign_To_Me();
 
     String Created_On();
+    
+    String Text_Require();
 }

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/resources/org/jbpm/console/ng/ht/client/i18n/Constants.properties
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/resources/org/jbpm/console/ng/ht/client/i18n/Constants.properties
@@ -53,3 +53,4 @@ Remove_Group=Remove Group
 Assignments=Assignments
 Auto_Assign_To_Me=Auto Assign To Me
 Created_On=Created On
+Text_Require=This text is required

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/resources/org/jbpm/console/ng/ht/client/i18n/Constants_es_AR.properties
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/resources/org/jbpm/console/ng/ht/client/i18n/Constants_es_AR.properties
@@ -53,3 +53,4 @@ Remove_Group=Quitar Grupo
 Assignments=Asignaciones
 Auto_Assign_To_Me=Asignar Automaticamente
 Created_On=Creada
+Text_Require=Este campo no puede estar vacio


### PR DESCRIPTION
- Users: link "add user", this button open a popup with the simple data of an user, this is name of user and a listBox with groups.
- Groups: link "add groups", similar to user, but it have only group name.
- All popups have the required validation in the text.
- All functionalities call your services of backend.
- The persistence even was not implemented.
