### PR TITLE
BZ 1174894 Process instance list sorting ends with an exception

### DIFF
--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/list/ProcessInstanceListViewImpl.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/list/ProcessInstanceListViewImpl.java
@@ -223,7 +223,17 @@ public class ProcessInstanceListViewImpl extends AbstractListView<ProcessInstanc
         columnMetas.add(new ColumnMeta<ProcessInstanceSummary>(processStateColumn, constants.State()));
         columnMetas.add(new ColumnMeta<ProcessInstanceSummary>(startTimeColumn, constants.Start_Date()));
         columnMetas.add(new ColumnMeta<ProcessInstanceSummary>(actionsColumn, constants.Actions()));
+        
         listGrid.addColumns(columnMetas);
+        
+        processInstanceIdColumn.setDataStoreName("ProcessInstanceId");
+        processNameColumn.setDataStoreName("ProcessName");
+        processInitiatorColumn.setDataStoreName("Initiator");
+        processVersionColumn.setDataStoreName("ProcessVersion");
+        processStateColumn.setDataStoreName("Status");
+        startTimeColumn.setDataStoreName("StartDate");
+        descriptionColumn.setDataStoreName("ProcessInstanceDescription");
+        
     }
 
     private void initBulkActionsDropDown() {
@@ -354,8 +364,6 @@ public class ProcessInstanceListViewImpl extends AbstractListView<ProcessInstanc
             }
         };
         processNameColumn.setSortable(true);
-        processNameColumn.setDataStoreName("ProcessName");
-
         return processNameColumn;
     }
 
@@ -368,8 +376,6 @@ public class ProcessInstanceListViewImpl extends AbstractListView<ProcessInstanc
             }
         };
         processInitiatorColumn.setSortable(true);
-        processInitiatorColumn.setDataStoreName("Initiator");
-
         return processInitiatorColumn;
     }
 
@@ -382,8 +388,6 @@ public class ProcessInstanceListViewImpl extends AbstractListView<ProcessInstanc
             }
         };
         processVersionColumn.setSortable(true);
-        processVersionColumn.setDataStoreName("ProcessVersion");
-
         return processVersionColumn;
     }
 
@@ -437,8 +441,6 @@ public class ProcessInstanceListViewImpl extends AbstractListView<ProcessInstanc
             }
         };
         startTimeColumn.setSortable(true);
-        startTimeColumn.setDataStoreName("StartDate");
-
         return startTimeColumn;
     }
 
@@ -502,7 +504,6 @@ public class ProcessInstanceListViewImpl extends AbstractListView<ProcessInstanc
             }
         };
         descriptionColumn.setSortable(true);
-        descriptionColumn.setDataStoreName("Description");
         return descriptionColumn;
     }
 


### PR DESCRIPTION
I find this issue reason is SimpleTable set default datastorename use caption.
So i re-set   datastorename after listGrid.addColumns(columnMetas);
Code in here
https://github.com/uberfire/uberfire-extensions/blob/master/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.java#L380

This is workaround way, best way should be remove default datastorename.
here:https://github.com/uberfire/uberfire-extensions/pull/8
But, i do not know is it reasonable .
Please check it.