### PR TITLE
Remove Sonatype OSS repository - not needed anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,16 +65,6 @@
         <updatePolicy>daily</updatePolicy>
       </snapshots>
     </repository>
-    <repository>
-      <id>sonatype</id>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
   </repositories>
 
   <build>


### PR DESCRIPTION
@Salaboy @mswiderski I believe the Sonatype repo is not needed (anymore). I did full build, starting with empty local maven repo dir to make sure nothing is cached and the build was successful. Do you know about use case that would require this repo?

We should not use any third party repos to ensure builds are reproducible, fast, etc. See https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/blob/master/README.md#requirements-for-dependencies for more details.