### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/jbpm-console-ng-ht-showcase/src/main/resources/ErraiApp.properties
+++ b/jbpm-console-ng-ht-showcase/src/main/resources/ErraiApp.properties
@@ -30,4 +30,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/jbpm-console-ng-ht-showcase/src/main/webapp/WEB-INF/web.xml
+++ b/jbpm-console-ng-ht-showcase/src/main/webapp/WEB-INF/web.xml
@@ -12,8 +12,16 @@
     <filter-name>request-capture</filter-name>
     <url-pattern>*</url-pattern>
   </filter-mapping>
-  
- 
+
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/jbpm-ht-console.html</url-pattern>
+  </filter-mapping>
 
   <servlet>
     <!-- NOTE: the integration-test profile uses this web.xml. Integration tests only work properly

--- a/jbpm-console-ng-showcase/src/main/resources/ErraiApp.properties
+++ b/jbpm-console-ng-showcase/src/main/resources/ErraiApp.properties
@@ -30,4 +30,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/jbpm-console-ng-showcase/src/main/webapp/WEB-INF/web.xml
+++ b/jbpm-console-ng-showcase/src/main/webapp/WEB-INF/web.xml
@@ -23,6 +23,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/jbpm-console.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.