### PR TITLE
Update TaskCommentsPresenterTest to verify callbacks

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/pom.xml
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/pom.xml
@@ -183,12 +183,25 @@
       <scope>runtime</scope>
     </dependency>
 
+    <!-- Test deps -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency><!-- to get CallerMock in unit test-->
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>


### PR DESCRIPTION
Extended task comments gwt unit test so that it now also verifies app.logic in callbacks. I used CallerMock from uberfire-testing-utils for this purpose. Using this I discovered and fixed an inefficiency - 2 superfluous calls to redrawDataGrid().