### PR TITLE
JBPM-4625 Generation of JPA enabled models

### DIFF
--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/pom.xml
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/pom.xml
@@ -97,6 +97,10 @@
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-services-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-project-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.kie</groupId>
@@ -110,6 +114,16 @@
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-data-modeller-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-data-modeller-backend</artifactId>
     </dependency>
 
     <dependency>

--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdater.java
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdater.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.wi.backend.server.dd;
+
+import java.util.ArrayList;
+import java.util.Date;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.jbpm.console.ng.wi.dd.model.DeploymentDescriptorModel;
+import org.jbpm.console.ng.wi.dd.model.ItemObjectModel;
+import org.jbpm.console.ng.wi.dd.service.DDEditorService;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.base.options.CommentedOption;
+import org.uberfire.workbench.events.ResourceAddedEvent;
+import org.uberfire.workbench.events.ResourceUpdatedEvent;
+
+@ApplicationScoped
+public class DDConfigUpdater {
+
+    private KieProjectService projectService;
+
+    private IOService ioService;
+
+    private DDEditorService ddEditorService;
+
+    private DDConfigUpdaterHelper configUpdaterHelper;
+
+    @Inject
+    public DDConfigUpdater( DDEditorService ddEditorService,
+                            KieProjectService projectService,
+                            @Named("ioStrategy") IOService ioService,
+                            DDConfigUpdaterHelper configUpdaterHelper ) {
+        this.ddEditorService = ddEditorService;
+        this.projectService = projectService;
+        this.ioService = ioService;
+        this.configUpdaterHelper = configUpdaterHelper;
+    }
+
+    public void processResourceAdd( @Observes final ResourceAddedEvent resourceAddedEvent ) {
+        if ( configUpdaterHelper.isPersistenceFile( resourceAddedEvent.getPath() ) ) {
+            //persistence.xml has been added to current project.
+            updateConfig( projectService.resolveProject( resourceAddedEvent.getPath() ) );
+        }
+    }
+
+    public void processResourceUpdate( @Observes final ResourceUpdatedEvent resourceUpdatedEvent ) {
+        if ( configUpdaterHelper.isPersistenceFile( resourceUpdatedEvent.getPath() ) ) {
+            //persistence.xml has been updated in current project.
+            updateConfig( projectService.resolveProject( resourceUpdatedEvent.getPath() ) );
+        }
+    }
+
+    private void updateConfig( final KieProject kieProject ) {
+
+        Path deploymentDescriptorPath = PathFactory.newPath( "kie-deployment-descriptor.xml",
+                kieProject.getRootPath().toURI() + "/src/main/resources/META-INF/kie-deployment-descriptor.xml" );
+
+        if ( ioService.exists( Paths.convert( deploymentDescriptorPath ) ) ) {
+            //if deployment descriptor exists created, then update it.
+            DeploymentDescriptorModel descriptorModel = ddEditorService.load( deploymentDescriptorPath );
+            updateMarshallingConfig( descriptorModel, deploymentDescriptorPath, kieProject );
+        }
+    }
+
+    private void updateMarshallingConfig( final DeploymentDescriptorModel descriptorModel,
+            final Path path, final KieProject kieProject ) {
+
+        String marshallingValue = configUpdaterHelper.buildJPAMarshallingStrategyValue( kieProject );
+        if ( marshallingValue != null ) {
+            if ( descriptorModel != null ) {
+                ItemObjectModel oldMarshallingStrategy = null;
+                if ( descriptorModel.getMarshallingStrategies() != null ) {
+                    //check if the marshalling strategy is already configured
+                    for ( ItemObjectModel itemModel: descriptorModel.getMarshallingStrategies() ) {
+                        if ( itemModel.getValue() != null &&
+                                itemModel.getValue().contains( "org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy" ) ) {
+                            oldMarshallingStrategy = itemModel;
+                            break;
+                        }
+                    }
+                    if ( oldMarshallingStrategy != null ) {
+                        descriptorModel.getMarshallingStrategies().remove( oldMarshallingStrategy );
+                    }
+                } else {
+                    descriptorModel.setMarshallingStrategies( new ArrayList<ItemObjectModel>() );
+                }
+
+                ItemObjectModel marshallingStrategy = new ItemObjectModel();
+                marshallingStrategy.setResolver( "mvel" );
+                marshallingStrategy.setValue( marshallingValue );
+                descriptorModel.getMarshallingStrategies().add( marshallingStrategy );
+                CommentedOption commentedOption = new CommentedOption( "system", null, "JPA marshalling strategy added by system", new Date() );
+                ( ( DDEditorServiceImpl ) ddEditorService ).save( path, descriptorModel, descriptorModel.getOverview().getMetadata(), commentedOption );
+
+            }
+        }
+    }
+
+}

--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdaterHelper.java
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdaterHelper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.wi.backend.server.dd;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.jbpm.runtime.manager.impl.deploy.DeploymentDescriptorImpl;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.kie.internal.runtime.conf.ObjectModel;
+import org.kie.workbench.common.screens.datamodeller.model.persistence.PersistenceDescriptorModel;
+import org.kie.workbench.common.screens.datamodeller.service.PersistenceDescriptorService;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+
+@ApplicationScoped
+public class DDConfigUpdaterHelper {
+
+    private KieProjectService projectService;
+
+    private IOService ioService;
+
+    private PersistenceDescriptorService pdService;
+
+    public DDConfigUpdaterHelper() {
+        //Injection required
+    }
+
+    @Inject
+    public DDConfigUpdaterHelper( KieProjectService projectService,
+            @Named("ioStrategy") IOService ioService,
+            PersistenceDescriptorService pdService ) {
+        this.projectService = projectService;
+        this.pdService = pdService;
+        this.ioService = ioService;
+    }
+
+    public boolean isPersistenceFile( Path path ) {
+        if ( path.getFileName().equals( "persistence.xml" ) ) {
+            KieProject kieProject = projectService.resolveProject( path );
+            String persistenceURI;
+            if ( kieProject != null && kieProject.getRootPath() != null ) {
+                //ok, we have a well formed project
+                persistenceURI = kieProject.getRootPath().toURI() + "/src/main/resources/META-INF/persistence.xml";
+                return persistenceURI.equals( path.toURI() );
+            }
+        }
+        return false;
+    }
+
+    public boolean hasPersistenceFile( Path path ) {
+
+        KieProject kieProject = projectService.resolveProject( path );
+        if ( kieProject != null && kieProject.getRootPath() != null ) {
+            //ok, we have a well formed project
+            String persistenceURI = kieProject.getRootPath().toURI() + "/src/main/resources/META-INF/persistence.xml";
+            Path persistencePath = PathFactory.newPath( "persistence.xml", persistenceURI );
+            return ioService.exists( Paths.convert( persistencePath ) );
+        }
+        return false;
+    }
+
+
+    public String buildJPAMarshallingStrategyValue( KieProject kieProject ) {
+        PersistenceDescriptorModel pdModel = pdService.load( kieProject );
+        if ( pdModel != null ) {
+            return "new org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy(\"" +  pdModel.getPersistenceUnit().getName() + "\", classLoader)";
+        }
+        return null;
+    }
+
+    public void addJPAMarshallingStrategy( DeploymentDescriptor dd, Path path ) {
+        KieProject kieProject = projectService.resolveProject( path );
+        String marshalingValue = null;
+        if ( kieProject != null && ( ( marshalingValue = buildJPAMarshallingStrategyValue( kieProject )) != null ) ) {
+            List<ObjectModel> marshallingStrategies = new ArrayList<ObjectModel>(  );
+            ObjectModel objectModel = new ObjectModel();
+            objectModel.setResolver( "mvel" );
+            objectModel.setIdentifier( marshalingValue );
+            marshallingStrategies.add( objectModel );
+            ((DeploymentDescriptorImpl )dd ).setMarshallingStrategies( marshallingStrategies );
+        }
+    }
+}


### PR DESCRIPTION
    - automatic adding/update of the JPAMarshalling strategy in the deployment-descriptor.xml when the persistence.xml is created/modified

Given that the deployment-descriptor.xml editor and the persistence.xml editor are completely decoupled, and also the deployment-descriptor.xml stuff is only included in WB's that includes the jbpm runtime, etc., the following PR implements the following functionality in order to maintain the marshalling strategy configuration well.

    1) when the persistence.xml is added/modified then if the deployment-descriptor.xml exist for the given project, then the JPAMarshalling strategy will be added/modified.

    2) when the deployment-descriptor.xml is created, if the persistence.xml exists for the given project, then the JPAMarshalling strategy configuration will be added to the just created descriptor.

Finally in all cases the user can always change the deployment-descriptor.xml using the editor, and eventually remove the buy default added configuration.



