### PR TITLE
Add missing test coverage for BZ-1171810

### DIFF
--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/pom.xml
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/pom.xml
@@ -170,6 +170,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/backend/server/DeploymentManagerEntryPointImpl.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/backend/server/DeploymentManagerEntryPointImpl.java
@@ -177,7 +177,7 @@ public class DeploymentManagerEntryPointImpl implements DeploymentManagerEntryPo
     GAV gav = new GAV(gavElemes[0], gavElemes[1], gavElemes[2]);
     BuildResults buildResults = new BuildResults(gav);
     BuildMessage message = new BuildMessage();
-    message.setLevel(Level.ERROR);
+    message.setLevel(level);
     message.setText(messageText);
     buildResults.addBuildMessage(message);
 

--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/test/java/org/jbpm/console/ng/bd/backend/server/DeploymentManagerEntryPointImplTest.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/test/java/org/jbpm/console/ng/bd/backend/server/DeploymentManagerEntryPointImplTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.console.ng.bd.backend.server;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import javax.enterprise.event.Event;
+
+import org.guvnor.common.services.project.builder.model.BuildMessage;
+import org.guvnor.common.services.project.builder.model.BuildResults;
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.m2repo.backend.server.GuvnorM2Repository;
+import org.guvnor.structure.server.config.ConfigurationService;
+import org.jbpm.services.api.DeploymentService;
+import org.jbpm.services.api.model.DeployedUnit;
+import org.jbpm.services.api.model.DeploymentUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeploymentManagerEntryPointImplTest {
+
+    @Mock
+    private DeploymentService deploymentService;
+    @Mock
+    private GuvnorM2Repository guvnorM2Repository;
+    @Mock
+    private ConfigurationService configurationService;
+    @Mock
+    private Event<BuildResults> buildResultsEvent;
+
+    @InjectMocks
+    private DeploymentManagerEntryPointImpl deploymentManager;
+
+    @Before
+    public void setUp() {
+        // call @PostConstruct hook
+        deploymentManager.configure();
+    }
+
+    /**
+     * Test coverage for BZ-1171810.
+     */
+    @Test
+    public void testDuplicateDeployment() {
+        when(deploymentService.isDeployed(anyString())).thenReturn(true);
+
+        GAV gav = new GAV("g:a:1");
+        BuildResults result = new BuildResults(gav);
+        deploymentManager.process(result);
+
+        verify(deploymentService, atLeast(1)).isDeployed("g:a:1");
+        verify(deploymentService, never()).undeploy((DeploymentUnit) any(DeployedUnit.class));
+        verify(deploymentService, never()).deploy((DeploymentUnit) any(DeployedUnit.class));
+
+        assertNotEquals(0, result.getErrorMessages().size());
+        for (BuildMessage msg : result.getErrorMessages()) {
+            assertTrue(msg.getText(), msg.getText().contains("already deployed"));
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up for cdb2ba32f6 and 464fd12fe9 which are fixes provided with no test coverage. Another purpose of this PR is to allow QE to reduce time-consuming UI test suite.
