### PR TITLE
Fix regex to allow more types of version strings

### DIFF
--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-client/src/test/java/org/jbpm/console/ng/wi/client/editors/deployment/descriptor/DeploymentDescriptorViewTest.java
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-client/src/test/java/org/jbpm/console/ng/wi/client/editors/deployment/descriptor/DeploymentDescriptorViewTest.java
@@ -179,7 +179,7 @@ public class DeploymentDescriptorViewTest {
 
     }
 
-    private static final String jarLocRegexStr = "([\\d\\.]{3})\\.\\d(-SNAPSHOT)?";
+    private static final String jarLocRegexStr = "([\\d\\.]{3})\\S*";
     private static final Pattern jarLocRegex = Pattern.compile(jarLocRegexStr);
 
     @Test


### PR DESCRIPTION
 * we need the version strings 6.4.0.2015011 or 6.4.0.test to
   work as well

@mrietveld could you please review this? 