### PR TITLE
GUVNOR-2273 : Replace "package name white list" with DependencyFilter and related UI improvements

### DIFF
--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDEditorServiceImpl.java
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDEditorServiceImpl.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
@@ -55,39 +56,42 @@ public class DDEditorServiceImpl
         implements DDEditorService {
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
     private DDConfigUpdaterHelper configUpdaterHelper;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
     @Override
-    public DeploymentDescriptorModel load(Path path) {
-        return super.loadContent(path);
+    public DeploymentDescriptorModel load( Path path ) {
+        return super.loadContent( path );
     }
 
     @Override
-    protected DeploymentDescriptorModel constructContent(Path path, Overview overview) {
+    protected DeploymentDescriptorModel constructContent( Path path, Overview overview ) {
 
-        InputStream input = ioService.newInputStream(Paths.convert(path));
+        InputStream input = ioService.newInputStream( Paths.convert( path ) );
 
-        org.kie.internal.runtime.conf.DeploymentDescriptor originDD = DeploymentDescriptorIO.fromXml(input);
+        org.kie.internal.runtime.conf.DeploymentDescriptor originDD = DeploymentDescriptorIO.fromXml( input );
 
-        DeploymentDescriptorModel ddModel = marshal(originDD);
+        DeploymentDescriptorModel ddModel = marshal( originDD );
 
-        ddModel.setOverview(overview);
+        ddModel.setOverview( overview );
 
         return ddModel;
     }
 
     @Override
-    public Path save(Path path, DeploymentDescriptorModel content, Metadata metadata, String comment) {
+    public Path save( Path path, DeploymentDescriptorModel content, Metadata metadata, String comment ) {
 
         try {
-            save( path, content, metadata, makeCommentedOption( comment ) );
+            save( path, content, metadata, commentedOptionFactory.makeCommentedOption( comment ) );
             return path;
-        } catch (Exception e) {
-            throw ExceptionUtilities.handleException(e);
+        } catch ( Exception e ) {
+            throw ExceptionUtilities.handleException( e );
         }
     }
 
@@ -95,43 +99,43 @@ public class DDEditorServiceImpl
     public Path save( Path path, DeploymentDescriptorModel content, Metadata metadata, CommentedOption commentedOption ) {
 
         try {
-            String deploymentContent = unmarshal(path, content).toXml();
+            String deploymentContent = unmarshal( path, content ).toXml();
 
             Metadata currentMetadata = metadataService.getMetadata( path );
-            ioService.write(Paths.convert(path),
-                    deploymentContent,
-                    metadataService.setUpAttributes(path,
-                            metadata),
-                    commentedOption);
+            ioService.write( Paths.convert( path ),
+                             deploymentContent,
+                             metadataService.setUpAttributes( path,
+                                                              metadata ),
+                             commentedOption );
 
             fireMetadataSocialEvents( path, currentMetadata, metadata );
 
             return path;
-        } catch (Exception e) {
-            throw ExceptionUtilities.handleException(e);
+        } catch ( Exception e ) {
+            throw ExceptionUtilities.handleException( e );
         }
     }
 
     @Override
-    public List<ValidationMessage> validate(Path path, DeploymentDescriptorModel content) {
+    public List<ValidationMessage> validate( Path path, DeploymentDescriptorModel content ) {
         final List<ValidationMessage> validationMessages = new ArrayList<ValidationMessage>();
         try {
-            unmarshal(path, content).toXml();
-        } catch (Exception e) {
+            unmarshal( path, content ).toXml();
+        } catch ( Exception e ) {
             final ValidationMessage msg = new ValidationMessage();
-            msg.setPath(path);
-            msg.setLevel(Level.ERROR);
-            msg.setText(e.getMessage());
-            validationMessages.add(msg);
+            msg.setPath( path );
+            msg.setLevel( Level.ERROR );
+            msg.setText( e.getMessage() );
+            validationMessages.add( msg );
         }
 
         return validationMessages;
     }
 
     @Override
-    public String toSource(Path path, DeploymentDescriptorModel model) {
+    public String toSource( Path path, DeploymentDescriptorModel model ) {
         try {
-            return unmarshal(path, model).toXml();
+            return unmarshal( path, model ).toXml();
 
         } catch ( Exception e ) {
             throw ExceptionUtilities.handleException( e );


### PR DESCRIPTION
Scope is no longer editable in the dependency grid.
You can white list the packages in the listed jar or remove from the white list.
Transient dependencies are also listed.
Packages in the current project are always white listed, but everything else needs to be added.
Also removed some redundant code and split few classes into smaller units.

https://github.com/droolsjbpm/kie-docs/pull/32
https://github.com/droolsjbpm/guvnor/pull/219
https://github.com/droolsjbpm/kie-wb-common/pull/202
https://github.com/droolsjbpm/drools-wb/pull/108
https://github.com/droolsjbpm/jbpm-console-ng/pull/261
https://github.com/droolsjbpm/jbpm-form-modeler/pull/32