### PR TITLE
JBPM-4849: Add ability to hide asset management process definitions (6.4.x)

### DIFF
--- a/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/pom.xml
+++ b/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/pom.xml
@@ -25,6 +25,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-internal</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-kie-services</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-console-ng-dashboard-api</artifactId>
     </dependency>
@@ -48,5 +58,12 @@
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-dataset-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-dataset-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/src/main/java/org/jbpm/dashboard/renderer/backend/DeploymentIdsPreprocessor.java
+++ b/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/src/main/java/org/jbpm/dashboard/renderer/backend/DeploymentIdsPreprocessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.dashboard.renderer.backend;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.def.DataSetPreprocessor;
+import org.dashbuilder.dataset.filter.DataSetFilter;
+import org.jbpm.kie.services.impl.security.DeploymentRolesManager;
+import org.kie.internal.identity.IdentityProvider;
+
+import static org.dashbuilder.dataset.filter.FilterFactory.*;
+import static org.jbpm.dashboard.renderer.model.DashboardData.*;
+
+/**
+ * Ensure any Process Instances data set lookup call is constrained
+ * according the process deployment ids the user may see.
+ */
+public class DeploymentIdsPreprocessor implements DataSetPreprocessor {
+
+    @Inject
+    DeploymentRolesManager deploymentRolesManager;
+
+    @Inject
+    IdentityProvider identityProvider;
+
+    @Override
+    public void preprocess(DataSetLookup lookup) {
+        List<String> deploymentIds = deploymentRolesManager.getDeploymentsForUser(identityProvider);
+        DataSetFilter filter = new DataSetFilter();
+        filter.addFilterColumn(in(COLUMN_PROCESS_EXTERNAL_ID, deploymentIds));
+        lookup.addOperation(0, filter);
+    }
+}

--- a/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/src/test/java/org/jbpm/dashboard/renderer/backend/DataSetDefsBootstrapTest.java
+++ b/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/src/test/java/org/jbpm/dashboard/renderer/backend/DataSetDefsBootstrapTest.java
@@ -15,39 +15,112 @@
  */
 package org.jbpm.dashboard.renderer.backend;
 
+import java.util.Arrays;
 import java.util.List;
 
+import org.dashbuilder.DataSetCore;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetLookupFactory;
+import org.dashbuilder.dataset.DataSetManager;
 import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefRegistry;
+import org.jbpm.kie.services.impl.security.DeploymentRolesManager;
+import org.jbpm.persistence.settings.JpaSettings;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.internal.identity.IdentityProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.dashbuilder.dataset.filter.FilterFactory.in;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.jbpm.dashboard.renderer.backend.DataSetDefsBootstrap.*;
+import static org.jbpm.dashboard.renderer.model.DashboardData.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DataSetDefsBootstrapTest {
 
     @Mock
-    DataSetDefRegistry dataSetDefRegistryMock;
+    DeploymentRolesManager deploymentRolesManager;
+
+    @Mock
+    IdentityProvider identityProvider;
+
+    @Mock
+    JpaSettings jpaSettings;
+
+    @Spy
+    DeploymentIdsPreprocessor deploymentIdsPreprocessor;
+
+    @Spy
+    DataSetDefRegistry dataSetRegistry = DataSetCore.get().getDataSetDefRegistry();
+
+    @Spy
+    DataSetManager dataSetManager = DataSetCore.get().getDataSetManager();
 
     @InjectMocks
     DataSetDefsBootstrap dataSetsBootstrap;
 
-    @Test
-    public void registerDataSetDefinitionsTest() {
+    List<String> deploymentIds = Arrays.asList("role1", "role2");
+
+    @Before
+    public void setUp() {
+        // The two lines below is Mockito's issue work-around:
+        // Can not use @_InjectMocks together with a @Spy annotation => https://github.com/mockito/mockito/issues/169
+        deploymentIdsPreprocessor.deploymentRolesManager = deploymentRolesManager;
+        deploymentIdsPreprocessor.identityProvider = identityProvider;
+
         dataSetsBootstrap.registerDataSetDefinitions();
+        when(deploymentRolesManager.getDeploymentsForUser(identityProvider)).thenReturn(deploymentIds);
+    }
+
+    @Test
+    public void registerDataSetDefsTest() {
         ArgumentCaptor<DataSetDef> argument = ArgumentCaptor.forClass(DataSetDef.class);
-        verify(dataSetDefRegistryMock, times(2)).registerDataSetDef(argument.capture());
+        verify(dataSetRegistry, times(2)).registerDataSetDef(argument.capture());
 
         List<DataSetDef> dataSetDefList = argument.getAllValues();
         assertEquals(dataSetDefList.size(), 2);
         assertEquals(dataSetDefList.get(0).getUUID(), PROCESSES_MONITORING_DATASET);
         assertEquals(dataSetDefList.get(1).getUUID(), TASKS_MONITORING_DATASET);
+    }
+
+    @Test
+    public void procInstancesPreprocessorTest() {
+        DataSetLookup lookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(PROCESSES_MONITORING_DATASET)
+                .buildLookup();
+
+        dataSetManager.lookupDataSet(lookup);
+        ArgumentCaptor<DataSetLookup> argument = ArgumentCaptor.forClass(DataSetLookup.class);
+
+        verify(deploymentIdsPreprocessor).preprocess(lookup);
+        verify(dataSetManager).lookupDataSet(argument.capture());
+        assertEquals(argument.getValue(), DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(PROCESSES_MONITORING_DATASET)
+                .filter(in(COLUMN_PROCESS_EXTERNAL_ID, deploymentIds))
+                .buildLookup());
+    }
+
+    @Test
+    public void tasksPreprocessorTest() {
+        DataSetLookup lookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(TASKS_MONITORING_DATASET)
+                .buildLookup();
+
+        dataSetManager.lookupDataSet(lookup);
+        ArgumentCaptor<DataSetLookup> argument = ArgumentCaptor.forClass(DataSetLookup.class);
+
+        verify(deploymentIdsPreprocessor).preprocess(lookup);
+        verify(dataSetManager).lookupDataSet(argument.capture());
+        assertEquals(argument.getValue(), DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(TASKS_MONITORING_DATASET)
+                .filter(in(COLUMN_PROCESS_EXTERNAL_ID, deploymentIds))
+                .buildLookup());
     }
 }

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/dash/DataSetTasksListGridPresenter.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/dash/DataSetTasksListGridPresenter.java
@@ -66,6 +66,7 @@ import org.uberfire.workbench.model.menu.Menus;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
 import static org.dashbuilder.dataset.filter.FilterFactory.*;
+import static org.jbpm.console.ng.ht.model.TaskDataSetConstants.*;
 
 @Dependent
 @WorkbenchScreen( identifier = "DataSet Tasks List" )
@@ -142,7 +143,7 @@ public class DataSetTasksListGridPresenter extends AbstractScreenListPresenter<T
                         dataSetQueryHelper.setLastOrderedColumn( ( columnSortList.size() > 0 ) ? columnSortList.get( 0 ).getColumn().getDataStoreName() : "" );
                         dataSetQueryHelper.setLastSortOrder( ( columnSortList.size() > 0 ) && columnSortList.get( 0 ).isAscending() ? SortOrder.ASCENDING : SortOrder.DESCENDING );
                     } else {
-                        dataSetQueryHelper.setLastOrderedColumn( DataSetTasksListGridViewImpl.COLUMN_CREATEDON );
+                        dataSetQueryHelper.setLastOrderedColumn( COLUMN_CREATEDON );
                         dataSetQueryHelper.setLastSortOrder( SortOrder.ASCENDING );
                     }
 
@@ -150,9 +151,9 @@ public class DataSetTasksListGridPresenter extends AbstractScreenListPresenter<T
 
                         DataSetFilter filter = new DataSetFilter();
                         List<ColumnFilter> filters = new ArrayList<ColumnFilter>();
-                        filters.add( likeTo( DataSetTasksListGridViewImpl.COLUMN_NAME, "%" + textSearchStr.toLowerCase() + "%", false ) );
-                        filters.add( likeTo( DataSetTasksListGridViewImpl.COLUMN_DESCRIPTION, "%" + textSearchStr.toLowerCase() + "%", false ) );
-                        filters.add( likeTo( DataSetTasksListGridViewImpl.COLUMN_PROCESSID, "%" + textSearchStr.toLowerCase() + "%", false ) );
+                        filters.add( likeTo( COLUMN_NAME, "%" + textSearchStr.toLowerCase() + "%", false ) );
+                        filters.add( likeTo( COLUMN_DESCRIPTION, "%" + textSearchStr.toLowerCase() + "%", false ) );
+                        filters.add( likeTo( COLUMN_PROCESSID, "%" + textSearchStr.toLowerCase() + "%", false ) );
                         filter.addFilterColumn( OR( filters ) );
 
                         if ( currentTableSettings.getDataSetLookup().getFirstFilterOp() != null ) {
@@ -171,21 +172,21 @@ public class DataSetTasksListGridPresenter extends AbstractScreenListPresenter<T
 
                                 for ( int i = 0; i < dataSet.getRowCount(); i++ ) {
                                     myTasksFromDataSet.add( new TaskSummary(
-                                            dataSetQueryHelper.getColumnLongValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_TASKID, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_NAME, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_DESCRIPTION, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_STATUS, i ),
-                                            dataSetQueryHelper.getColumnIntValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_PRIORITY, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_ACTUALOWNER, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_CREATEDBY, i ),
-                                            dataSetQueryHelper.getColumnDateValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_CREATEDON, i ),
-                                            dataSetQueryHelper.getColumnDateValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_ACTIVATIONTIME, i ),
-                                            dataSetQueryHelper.getColumnDateValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_DUEDATE, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_PROCESSID, i ),
-                                            dataSetQueryHelper.getColumnLongValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_PROCESSSESSIONID, i ),
-                                            dataSetQueryHelper.getColumnLongValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_PROCESSINSTANCEID, i ),
-                                            dataSetQueryHelper.getColumnStringValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_DEPLOYMENTID, i ),
-                                            dataSetQueryHelper.getColumnLongValue( dataSet, DataSetTasksListGridViewImpl.COLUMN_PARENTID, i ) ) );
+                                            dataSetQueryHelper.getColumnLongValue( dataSet, COLUMN_TASKID, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_NAME, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_DESCRIPTION, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_STATUS, i ),
+                                            dataSetQueryHelper.getColumnIntValue( dataSet, COLUMN_PRIORITY, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_ACTUALOWNER, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_CREATEDBY, i ),
+                                            dataSetQueryHelper.getColumnDateValue( dataSet, COLUMN_CREATEDON, i ),
+                                            dataSetQueryHelper.getColumnDateValue( dataSet, COLUMN_ACTIVATIONTIME, i ),
+                                            dataSetQueryHelper.getColumnDateValue( dataSet, COLUMN_DUEDATE, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_PROCESSID, i ),
+                                            dataSetQueryHelper.getColumnLongValue( dataSet, COLUMN_PROCESSSESSIONID, i ),
+                                            dataSetQueryHelper.getColumnLongValue( dataSet, COLUMN_PROCESSINSTANCEID, i ),
+                                            dataSetQueryHelper.getColumnStringValue( dataSet, COLUMN_DEPLOYMENTID, i ),
+                                            dataSetQueryHelper.getColumnLongValue( dataSet, COLUMN_PARENTID, i ) ) );
 
                                 }
                                 PageResponse<TaskSummary> taskSummaryPageResponse = new PageResponse<TaskSummary>();

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/dash/DataSetTasksListGridViewImpl.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/dash/DataSetTasksListGridViewImpl.java
@@ -82,24 +82,6 @@ public class DataSetTasksListGridViewImpl extends AbstractMultiGridView<TaskSumm
 
     public static String DATASET_TASK_LIST_PREFIX = "DataSetTaskListGrid";
 
-    public static final String COLUMN_ACTIVATIONTIME = "activationTime";
-    public static final String COLUMN_ACTUALOWNER = "actualOwner";
-    public static final String COLUMN_CREATEDBY = "createdBy";
-    public static final String COLUMN_CREATEDON = "createdOn";
-    public static final String COLUMN_DEPLOYMENTID = "deploymentId";
-    public static final String COLUMN_DESCRIPTION = "description";
-    public static final String COLUMN_DUEDATE = "dueDate";
-    public static final String COLUMN_NAME = "name";
-    public static final String COLUMN_PARENTID = "parentId";
-    public static final String COLUMN_PRIORITY = "priority";
-    public static final String COLUMN_PROCESSID = "processId";
-    public static final String COLUMN_PROCESSINSTANCEID = "processInstanceId";
-    public static final String COLUMN_PROCESSSESSIONID = "processSessionId";
-    public static final String COLUMN_STATUS = "status";
-    public static final String COLUMN_TASKID = "taskId";
-    public static final String COLUMN_WORKITEMID = "workItemId";
-    public static final String COLUMN_ORGANIZATIONAL_ENTITY = "oeid";
-
     private final Constants constants = GWT.create( Constants.class );
     public static final String COL_ID_ACTIONS = "actions";
 

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/pom.xml
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/pom.xml
@@ -94,9 +94,15 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-persistence-jpa</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-dataset-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-dataset-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/main/java/org/jbpm/console/ng/pr/backend/server/DataSetDefsBootstrap.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/main/java/org/jbpm/console/ng/pr/backend/server/DataSetDefsBootstrap.java
@@ -36,11 +36,16 @@ public class DataSetDefsBootstrap {
     private static final Logger logger = LoggerFactory.getLogger(DataSetDefsBootstrap.class);
 
     @Inject
-    protected DataSetDefRegistry dataSetDefRegistry;
+    DataSetDefRegistry dataSetDefRegistry;
+
+    @Inject
+    DeploymentIdsPreprocessor deploymentIdsPreprocessor;
+
+    JpaSettings jpaSettings = JpaSettings.get();
 
     @PostConstruct
     protected void registerDataSetDefinitions() {
-        String jbpmDataSource = JpaSettings.get().getDataSourceJndiName();
+        String jbpmDataSource = jpaSettings.getDataSourceJndiName();
 
         DataSetDef processInstancesDef = DataSetDefFactory.newSQLDataSetDef()
                 .uuid(PROCESS_INSTANCE_DATASET)
@@ -94,5 +99,8 @@ public class DataSetDefsBootstrap {
         dataSetDefRegistry.registerDataSetDef(processInstancesDef);
         dataSetDefRegistry.registerDataSetDef(processWithVariablesDef);
         logger.info("Process instance datasets registered");
+
+        // Attach a preprocessor to ensure the user only sees the right process instances
+        dataSetDefRegistry.registerPreprocessor(PROCESS_INSTANCE_DATASET, deploymentIdsPreprocessor);
     }
 }

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/main/java/org/jbpm/console/ng/pr/backend/server/DeploymentIdsPreprocessor.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/main/java/org/jbpm/console/ng/pr/backend/server/DeploymentIdsPreprocessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.console.ng.pr.backend.server;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.def.DataSetPreprocessor;
+import org.dashbuilder.dataset.filter.DataSetFilter;
+import org.jbpm.kie.services.impl.security.DeploymentRolesManager;
+import org.kie.internal.identity.IdentityProvider;
+
+import static org.dashbuilder.dataset.filter.FilterFactory.*;
+import static org.jbpm.console.ng.pr.model.ProcessInstanceDataSetConstants.*;
+
+/**
+ * Ensure any Process Instances data set lookup call is constrained
+ * according the process deployment ids the user may see.
+ */
+public class DeploymentIdsPreprocessor implements DataSetPreprocessor {
+
+    @Inject
+    DeploymentRolesManager deploymentRolesManager;
+
+    @Inject
+    IdentityProvider identityProvider;
+
+    @Override
+    public void preprocess(DataSetLookup lookup) {
+        List<String> deploymentIds = deploymentRolesManager.getDeploymentsForUser(identityProvider);
+        DataSetFilter filter = new DataSetFilter();
+        filter.addFilterColumn(in(COLUMN_EXTERNALID, deploymentIds));
+        lookup.addOperation(0, filter);
+    }
+}

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/test/java/org/jbpm/console/ng/pr/backend/server/DataSetDefsBootstrapTest.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/test/java/org/jbpm/console/ng/pr/backend/server/DataSetDefsBootstrapTest.java
@@ -15,39 +15,94 @@
  */
 package org.jbpm.console.ng.pr.backend.server;
 
+import java.util.Arrays;
 import java.util.List;
 
+import org.dashbuilder.DataSetCore;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetLookupFactory;
+import org.dashbuilder.dataset.DataSetManager;
 import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefRegistry;
+import org.jbpm.kie.services.impl.security.DeploymentRolesManager;
+import org.jbpm.persistence.settings.JpaSettings;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.internal.identity.IdentityProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.jbpm.console.ng.pr.model.ProcessInstanceDataSetConstants.*;
+import static org.dashbuilder.dataset.filter.FilterFactory.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.jbpm.console.ng.pr.model.ProcessInstanceDataSetConstants.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DataSetDefsBootstrapTest {
 
     @Mock
-    DataSetDefRegistry dataSetDefRegistryMock;
+    DeploymentRolesManager deploymentRolesManager;
+
+    @Mock
+    IdentityProvider identityProvider;
+
+    @Mock
+    JpaSettings jpaSettings;
+
+    @Spy
+    DeploymentIdsPreprocessor deploymentIdsPreprocessor;
+
+    @Spy
+    DataSetDefRegistry dataSetRegistry = DataSetCore.get().getDataSetDefRegistry();
+
+    @Spy
+    DataSetManager dataSetManager = DataSetCore.get().getDataSetManager();
 
     @InjectMocks
     DataSetDefsBootstrap dataSetsBootstrap;
 
-    @Test
-    public void registerDataSetDefinitionsTest() {
+    List<String> deploymentIds = Arrays.asList("role1", "role2");
+
+    @Before
+    public void setUp() {
+        // The two lines below is Mockito's issue work-around:
+        // Can not use @_InjectMocks together with a @Spy annotation => https://github.com/mockito/mockito/issues/169
+        deploymentIdsPreprocessor.deploymentRolesManager = deploymentRolesManager;
+        deploymentIdsPreprocessor.identityProvider = identityProvider;
+
         dataSetsBootstrap.registerDataSetDefinitions();
+        when(deploymentRolesManager.getDeploymentsForUser(identityProvider)).thenReturn(deploymentIds);
+    }
+
+    @Test
+    public void registerDataSetDefsTest() {
         ArgumentCaptor<DataSetDef> argument = ArgumentCaptor.forClass(DataSetDef.class);
-        verify(dataSetDefRegistryMock, times(2)).registerDataSetDef(argument.capture());
+        verify(dataSetRegistry, times(2)).registerDataSetDef(argument.capture());
 
         List<DataSetDef> dataSetDefList = argument.getAllValues();
         assertEquals(dataSetDefList.size(), 2);
         assertEquals(dataSetDefList.get(0).getUUID(), PROCESS_INSTANCE_DATASET);
         assertEquals(dataSetDefList.get(1).getUUID(), PROCESS_INSTANCE_WITH_VARIABLES_DATASET);
+    }
+
+    @Test
+    public void procInstancesPreprocessorTest() {
+        DataSetLookup lookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(PROCESS_INSTANCE_DATASET)
+                .buildLookup();
+
+        dataSetManager.lookupDataSet(lookup);
+        ArgumentCaptor<DataSetLookup> argument = ArgumentCaptor.forClass(DataSetLookup.class);
+
+        verify(deploymentIdsPreprocessor).preprocess(lookup);
+        verify(dataSetManager).lookupDataSet(argument.capture());
+        assertEquals(argument.getValue(), DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(PROCESS_INSTANCE_DATASET)
+                .filter(in(COLUMN_EXTERNALID, deploymentIds))
+                .buildLookup());
     }
 }


### PR DESCRIPTION
Fix + unit tests.

I tested against EAP 6.4, both with and without the kiemgmt role and, as expected, the asset management instances are only shown when the kiemgtm role is present.

@cristianonicolai Can you please verify?