### PR TITLE
JBPM-4938: MSSQL2012: exception when trying to configure task filter …

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/DataSetDefsBootstrap.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/DataSetDefsBootstrap.java
@@ -136,8 +136,7 @@ public class DataSetDefsBootstrap {
                         "       tvi.name varname,\n" +
                         "       tvi.value varvalue\n" +
                         " from TaskVariableImpl tvi,AuditTaskImpl at " +
-                        " where tvi.taskId = at.taskId " +
-                        " order by tvi.taskId, tvi.name ", false)
+                        " where tvi.taskId = at.taskId ", false)
                .number(COLUMN_TASK_VARIABLE_TASKID)
                .label(COLUMN_TASK_VARIABLE_TASKNAME)
                .label(COLUMN_TASK_VARIABLE_NAME)

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/test/java/org/jbpm/console/ng/ht/backend/server/DataSetDefsBootstrapTest.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/test/java/org/jbpm/console/ng/ht/backend/server/DataSetDefsBootstrapTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefRegistry;
+import org.dashbuilder.dataset.def.SQLDataSetDef;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -51,5 +52,19 @@ public class DataSetDefsBootstrapTest {
         assertEquals(dsList.get(1).getUUID(), HUMAN_TASKS_WITH_USER_DATASET);
         assertEquals(dsList.get(2).getUUID(), HUMAN_TASKS_WITH_ADMIN_DATASET);
         assertEquals(dsList.get(3).getUUID(), HUMAN_TASKS_WITH_VARIABLES_DATASET);
+    }
+
+    @Test
+    public void noOrderByPresentInDefinitionsSQLTest() {
+        dataSetsBootstrap.registerDataSetDefinitions();
+        ArgumentCaptor<DataSetDef> argument = ArgumentCaptor.forClass(DataSetDef.class);
+        verify(dataSetDefRegistryMock, times(4)).registerDataSetDef(argument.capture());
+
+        List<DataSetDef> dsList = argument.getAllValues();
+        assertNull(((SQLDataSetDef) dsList.get(0)).getDbSQL());
+        assertFalse(((SQLDataSetDef) dsList.get(1)).getDbSQL().contains("order by"));
+        assertFalse(((SQLDataSetDef) dsList.get(2)).getDbSQL().contains("order by"));
+        assertFalse(((SQLDataSetDef) dsList.get(3)).getDbSQL().contains("order by"));
+
     }
 }


### PR DESCRIPTION
…showing task variables
Removed "order by" from dataset definition to avoid problems with Microsoft Sql server. 