### PR TITLE
JBPM-4945: Postgresql: can't get metadata - jbpmHumanTasksWithVariables

### DIFF
--- a/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/src/main/java/org/jbpm/dashboard/renderer/backend/DataSetDefsBootstrap.java
+++ b/jbpm-console-ng-dashboard/jbpm-console-ng-dashboard-backend/src/main/java/org/jbpm/dashboard/renderer/backend/DataSetDefsBootstrap.java
@@ -63,7 +63,7 @@ public class DataSetDefsBootstrap {
                 .dbSQL("select p.processName, p.externalId, t.* " +
                         "from ProcessInstanceLog p " +
                         "inner join BAMTaskSummary t on (t.processInstanceId = p.processInstanceId) " +
-                        "inner join (select min(pk) pk from BAMTaskSummary group by taskId) d on t.pk=d.pk",
+                        "inner join (select min(pk) as pk from BAMTaskSummary group by taskId) d on t.pk=d.pk",
                         true)
                 .buildDef();
 

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/DataSetDefsBootstrap.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/DataSetDefsBootstrap.java
@@ -131,10 +131,10 @@ public class DataSetDefsBootstrap {
                 .uuid(HUMAN_TASKS_WITH_VARIABLES_DATASET)
                 .name("Domain Specific Task")
                 .dataSource(jbpmDataSource)
-                .dbSQL("select  tvi.taskId taskId ,\n" +
-                        "       at.name name,\n" +
-                        "       tvi.name varname,\n" +
-                        "       tvi.value varvalue\n" +
+                .dbSQL("select  tvi.taskId as taskId ,\n" +
+                        "       at.name as name,\n" +
+                        "       tvi.name as varname,\n" +
+                        "       tvi.value as varvalue\n" +
                         " from TaskVariableImpl tvi,AuditTaskImpl at " +
                         " where tvi.taskId = at.taskId ", false)
                .number(COLUMN_TASK_VARIABLE_TASKID)

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/main/java/org/jbpm/console/ng/pr/backend/server/DataSetDefsBootstrap.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-backend/src/main/java/org/jbpm/console/ng/pr/backend/server/DataSetDefsBootstrap.java
@@ -73,13 +73,13 @@ public class DataSetDefsBootstrap {
                 .uuid(PROCESS_INSTANCE_WITH_VARIABLES_DATASET)
                 .name("Domain Specific Process Instances")
                 .dataSource(jbpmDataSource)
-                .dbSQL("select pil.processInstanceId pid,\n" +
-                        "       pil.processId pname,\n" +
-                        "       v.id varid,\n" +
-                        "       v.variableId varname,\n" +
-                        "       v.value varvalue\n" +
+                .dbSQL("select pil.processInstanceId as pid,\n" +
+                        "       pil.processId as pname,\n" +
+                        "       v.id as varid,\n" +
+                        "       v.variableId as varname,\n" +
+                        "       v.value as varvalue\n" +
                         "from ProcessInstanceLog pil\n" +
-                        "  inner join (select vil.processInstanceId ,vil.variableId, MAX(vil.ID) maxvilid  FROM VariableInstanceLog vil\n" +
+                        "  inner join (select vil.processInstanceId ,vil.variableId, MAX(vil.ID) as maxvilid  FROM VariableInstanceLog vil\n" +
                         "  GROUP BY vil.processInstanceId, vil.variableId)  x\n" +
                         "    on (x.processInstanceId =pil.processInstanceId)\n" +
                         "  INNER JOIN VariableInstanceLog v\n" +


### PR DESCRIPTION
Modified the way of doing column aliases in the SQL query.
Using the clause AS that works in postgresql, db2, oracle, h2