### PR TITLE
[6.4.x] BZ-1203561 - Kbase name and ksession name not reflected in 'Deploymen…

### DIFF
--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-client/src/main/java/org/jbpm/console/ng/bd/client/editors/deployment/list/DeploymentUnitsListViewImpl.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-client/src/main/java/org/jbpm/console/ng/bd/client/editors/deployment/list/DeploymentUnitsListViewImpl.java
@@ -228,7 +228,7 @@ public class DeploymentUnitsListViewImpl extends AbstractListView<KModuleDeploym
             @Override
             public String getValue( KModuleDeploymentUnitSummary unit ) {
                 String kbaseName = unit.getKbaseName();
-                if ( kbaseName.equals( "" ) ) {
+                if ( kbaseName == null || kbaseName.trim().isEmpty() ) {
                     kbaseName = "DEFAULT";
                 }
                 return kbaseName;
@@ -246,7 +246,7 @@ public class DeploymentUnitsListViewImpl extends AbstractListView<KModuleDeploym
             @Override
             public String getValue( KModuleDeploymentUnitSummary unit ) {
                 String ksessionName = unit.getKsessionName();
-                if ( ksessionName.equals( "" ) ) {
+                if ( ksessionName == null || ksessionName.trim().isEmpty() ) {
                     ksessionName = "DEFAULT";
                 }
                 return ksessionName;

--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-client/src/test/java/org/jbpm/console/ng/bd/client/editors/deployment/list/DeploymentUnitsListViewTest.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-client/src/test/java/org/jbpm/console/ng/bd/client/editors/deployment/list/DeploymentUnitsListViewTest.java
@@ -15,12 +15,15 @@
  */
 package org.jbpm.console.ng.bd.client.editors.deployment.list;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.user.cellview.client.Column;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jbpm.console.ng.bd.client.i18n.Constants;
 import org.jbpm.console.ng.bd.model.KModuleDeploymentUnitSummary;
 import org.jbpm.console.ng.gc.client.experimental.grid.base.ExtendedPagedTable;
-import org.jbpm.console.ng.ht.model.TaskSummary;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -41,6 +44,8 @@ public class DeploymentUnitsListViewTest {
     @InjectMocks
     private DeploymentUnitsListViewImpl view;
 
+
+
     @Test
     public void testDataStoreNameIsSet() {
         doAnswer( new Answer() {
@@ -57,6 +62,83 @@ public class DeploymentUnitsListViewTest {
         view.initColumns(currentListGrid);
 
         verify( currentListGrid ).addColumns(anyList());
+    }
+
+
+    @Test
+    public void testKBaseColumnValueSetToDefault() {
+
+        final KModuleDeploymentUnitSummary unitWithNull = new KModuleDeploymentUnitSummary("a:b:c", "a", "b", "c", null, null, "Singleton", "MERGE_COLLECTIONS");
+        final KModuleDeploymentUnitSummary unitEmptyString = new KModuleDeploymentUnitSummary("a:b:c", "a", "b", "c", "", "", "Singleton", "MERGE_COLLECTIONS");
+        final KModuleDeploymentUnitSummary unitWhiteSpace = new KModuleDeploymentUnitSummary("a:b:c", "a", "b", "c", "    ", "   ", "Singleton", "MERGE_COLLECTIONS");
+
+        doAnswer( new Answer() {
+            @Override
+            public Void answer( InvocationOnMock invocationOnMock ) throws Throwable {
+                final List<ColumnMeta> columns = (List<ColumnMeta>) invocationOnMock.getArguments()[ 0 ];
+                for ( ColumnMeta columnMeta : columns ) {
+                    if (columnMeta.getCaption().equals("KieBaseName")) {
+                        Column column = columnMeta.getColumn();
+
+                        Object value = column.getValue(unitWithNull);
+                        assertNotNull(value);
+                        assertEquals("DEFAULT", value);
+
+                        value = column.getValue(unitEmptyString);
+                        assertNotNull(value);
+                        assertEquals("DEFAULT", value);
+
+                        value = column.getValue(unitWhiteSpace);
+                        assertNotNull(value);
+                        assertEquals("DEFAULT", value);
+                    }
+                }
+                return null;
+            }
+        } ).when( currentListGrid ).addColumns(anyList());
+
+        view.initColumns(currentListGrid);
+
+        verify( currentListGrid ).addColumns(anyList());
+
+    }
+
+    @Test
+    public void testKSessionColumnValueSetToDefault() {
+
+        final KModuleDeploymentUnitSummary unitWithNull = new KModuleDeploymentUnitSummary("a:b:c", "a", "b", "c", null, null, "Singleton", "MERGE_COLLECTIONS");
+        final KModuleDeploymentUnitSummary unitEmptyString = new KModuleDeploymentUnitSummary("a:b:c", "a", "b", "c", "", "", "Singleton", "MERGE_COLLECTIONS");
+        final KModuleDeploymentUnitSummary unitWhiteSpace = new KModuleDeploymentUnitSummary("a:b:c", "a", "b", "c", "    ", "   ", "Singleton", "MERGE_COLLECTIONS");
+
+        doAnswer( new Answer() {
+            @Override
+            public Void answer( InvocationOnMock invocationOnMock ) throws Throwable {
+                final List<ColumnMeta> columns = (List<ColumnMeta>) invocationOnMock.getArguments()[ 0 ];
+                for ( ColumnMeta columnMeta : columns ) {
+                    if (columnMeta.getCaption().equals("KieSessionName")) {
+                        Column column = columnMeta.getColumn();
+
+                        Object value = column.getValue(unitWithNull);
+                        assertNotNull(value);
+                        assertEquals("DEFAULT", value);
+
+                        value = column.getValue(unitEmptyString);
+                        assertNotNull(value);
+                        assertEquals("DEFAULT", value);
+
+                        value = column.getValue(unitWhiteSpace);
+                        assertNotNull(value);
+                        assertEquals("DEFAULT", value);
+                    }
+                }
+                return null;
+            }
+        } ).when( currentListGrid ).addColumns(anyList());
+
+        view.initColumns(currentListGrid);
+
+        verify( currentListGrid ).addColumns(anyList());
+
     }
 
 }


### PR DESCRIPTION
…ts Unit' page if we deploy kjar through REST API

(cherry picked from commit 0e86f4ef6dc344433be8376e3b1cd52081d54939)