### PR TITLE
Use DefaultErrorCallback where possible

### DIFF
--- a/jbpm-console-ng-documents/jbpm-console-ng-documents-client/src/main/java/org/jbpm/console/ng/dm/client/document/CMISconfig/CMISConfigurationPresenter.java
+++ b/jbpm-console-ng-documents/jbpm-console-ng-documents-client/src/main/java/org/jbpm/console/ng/dm/client/document/CMISconfig/CMISConfigurationPresenter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jbpm.console.ng.dm.client.document.CMISconfig;
 
 import java.util.HashMap;
@@ -26,9 +25,7 @@ import com.google.gwt.core.client.GWT;
 import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.dm.client.i18n.Constants;
 import org.jbpm.console.ng.dm.service.DocumentServiceEntryPoint;
@@ -41,6 +38,7 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.client.workbench.widgets.split.WorkbenchSplitLayoutPanel;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.Command;
@@ -56,203 +54,182 @@ import org.uberfire.workbench.model.menu.Menus;
 @WorkbenchScreen(identifier = "CMIS Configuration")
 public class CMISConfigurationPresenter {
 
-	private PlaceRequest place;
+    private PlaceRequest place;
 
-	public interface CMISConfigurationView extends
-			UberView<CMISConfigurationPresenter> {
+    public interface CMISConfigurationView extends
+            UberView<CMISConfigurationPresenter> {
 
-		TextBox getWSACLTextBox();
-		
-		TextBox getWSDiscoveryTextBox();
-		
-		TextBox getWSMultifilingTextBox();
-		
-		TextBox getWSNavigationTextBox();
-		
-		TextBox getWSObjectTextBox();
-		
-		TextBox getWSPolicyTextBox();
-		
-		TextBox getWSRelationshipTextBox();
-		
-		TextBox getWSRepositoryTextBox();
-		
-		TextBox getWSVersioningTextBox();
-		
-		TextBox getRepositoryIDTextBox();
-				
-		TextBox getUserTextBox();
-		
-		TextBox getPasswordTextBox();
+        TextBox getWSACLTextBox();
 
-		void displayNotification(String text);
+        TextBox getWSDiscoveryTextBox();
 
-		void displayNotification(String text,NotificationType type);
+        TextBox getWSMultifilingTextBox();
 
-		Button getConfigureButton();
-		
-		Button getTestButton();
+        TextBox getWSNavigationTextBox();
 
-	}
+        TextBox getWSObjectTextBox();
 
-	private Menus menus;
+        TextBox getWSPolicyTextBox();
 
-	@Inject
-	private ErrorPopupPresenter errorPopup;
+        TextBox getWSRelationshipTextBox();
 
-	@Inject
-	private PlaceManager placeManager;
+        TextBox getWSRepositoryTextBox();
 
-	private Constants constants = GWT.create(Constants.class);
+        TextBox getWSVersioningTextBox();
 
-	@Inject
-	private CMISConfigurationView view;
+        TextBox getRepositoryIDTextBox();
 
-	@Inject
-	private Caller<DocumentServiceEntryPoint> dataServices;
+        TextBox getUserTextBox();
 
-	private Map<String, String> configurationParameters;
+        TextBox getPasswordTextBox();
 
-	public CMISConfigurationPresenter() {
-		makeMenuBar();
-	}
+        void displayNotification(String text);
 
-	@DefaultPosition
-	public Position getPosition() {
-		return CompassPosition.EAST;
-	}
+        void displayNotification(String text, NotificationType type);
 
-	@OnStartup
-	public void onStartup(final PlaceRequest place) {
-		this.place = place;
-		
-		configurationParameters = new HashMap<String, String>();
-	}
+        Button getConfigureButton();
 
-	@WorkbenchPartTitle
-	public String getTitle() {
-		return constants.ConfigurationPanel();
-	}
+        Button getTestButton();
 
-	@WorkbenchPartView
-	public UberView<CMISConfigurationPresenter> getView() {
-		return view;
-	}
+    }
 
-	private void changeStyleRow(String processDefName, String processDefVersion) {
-		// processDefStyleEvent.fire( new ProcessDefStyleEvent( processDefName,
-		// processDefVersion ) );
-	}
+    private Menus menus;
 
-	public void refreshConfigurationParameters() {
-		dataServices.call(new RemoteCallback<Map<String,String>>() {
-			@Override
-			public void callback(Map<String,String> parameters) {
-				view.getWSACLTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_ACL_SERVICE));
-				view.getWSDiscoveryTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_DISCOVERY_SERVICE));
-				view.getWSMultifilingTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_MULTIFILING_SERVICE));
-				view.getWSNavigationTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_NAVIGATION_SERVICE));
-				view.getWSObjectTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_OBJECT_SERVICE));
-				view.getWSPolicyTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_POLICY_SERVICE));
-				view.getWSRelationshipTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_RELATIONSHIP_SERVICE));
-				view.getWSRepositoryTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_REPOSITORY_SERVICE));
-				view.getWSVersioningTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_VERSIONING_SERVICE));
-				view.getRepositoryIDTextBox().setText(parameters.get(SessionParameter.REPOSITORY_ID));
-				view.getUserTextBox().setText(parameters.get(SessionParameter.USER));
-				view.getPasswordTextBox().setText(parameters.get(SessionParameter.PASSWORD));
-			}
-		}, new ErrorCallback<Message>() {
-			@Override
-			public boolean error(Message message, Throwable throwable) {
-				org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-				return true;
-			}
-		}).getConfigurationParameters();
-	}
+    @Inject
+    private ErrorPopupPresenter errorPopup;
 
-	@OnOpen
-	public void onOpen() {
-		WorkbenchSplitLayoutPanel splitPanel = (WorkbenchSplitLayoutPanel) view
-				.asWidget().getParent().getParent().getParent().getParent()
-				.getParent().getParent().getParent().getParent().getParent()
-				.getParent().getParent();
-		splitPanel.setWidgetMinSize(splitPanel.getWidget(0), 500);
-		refreshConfigurationParameters();
-	}
+    @Inject
+    private PlaceManager placeManager;
 
-	public void configureParameters() {
-		
-		HashMap<String,String> parameters = new HashMap<String, String>();
-		parameters.put(SessionParameter.WEBSERVICES_ACL_SERVICE, view.getWSACLTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_DISCOVERY_SERVICE,view.getWSDiscoveryTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_MULTIFILING_SERVICE,view.getWSMultifilingTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_NAVIGATION_SERVICE,view.getWSNavigationTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_OBJECT_SERVICE,view.getWSObjectTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_POLICY_SERVICE,view.getWSPolicyTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_RELATIONSHIP_SERVICE,view.getWSRelationshipTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_REPOSITORY_SERVICE,view.getWSRepositoryTextBox().getText());
-		parameters.put(SessionParameter.WEBSERVICES_VERSIONING_SERVICE,view.getWSVersioningTextBox().getText());
-		parameters.put(SessionParameter.REPOSITORY_ID,view.getRepositoryIDTextBox().getText());
-		parameters.put(SessionParameter.USER,view.getUserTextBox().getText());
-		parameters.put(SessionParameter.PASSWORD,view.getPasswordTextBox().getText());
-				
-		dataServices.call(new RemoteCallback<Long>() {
-            @Override
-            public void callback(Long taskId) {
-                view.displayNotification("Updated", NotificationType.SUCCESS);
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error(Message message, Throwable throwable) {
-				errorPopup.showMessage("Unexpected error encountered : " + throwable.getMessage());
-                return true;
-            }
-        }).setConfigurationParameters(parameters);
-	}
-	
-	public void testConnection(){
-		dataServices.call(new RemoteCallback<Boolean>() {
-            @Override
-            public void callback(Boolean result) {
-                if (result){
-                	view.displayNotification("Connection Successfull", NotificationType.SUCCESS);
-                } else {
-                	view.displayNotification("Connection Failed", NotificationType.ERROR);
-                }
-                
-                	
-            	
-            	
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error(Message message, Throwable throwable) {
-				errorPopup.showMessage("Unexpected error encountered : " + throwable.getMessage());
-                return true;
-            }
-        }).testConnection();
-		
-	}
+    private Constants constants = GWT.create(Constants.class);
 
-	@WorkbenchMenu
-	public Menus getMenus() {
-		return menus;
-	}
+    @Inject
+    private CMISConfigurationView view;
 
-	private void makeMenuBar() {
-		menus = MenuFactory.newTopLevelMenu(constants.Refresh())
-				.respondsWith(new Command() {
-					@Override
-					public void execute() {
-						refreshConfigurationParameters();
-						view.displayNotification("Refresh complete.");
-					}
-				}).endMenu().build();
+    @Inject
+    private Caller<DocumentServiceEntryPoint> dataServices;
 
-	}
+    private Map<String, String> configurationParameters;
 
-	private List<MenuItem> getOptions() {
-		return null;
-	}
+    public CMISConfigurationPresenter() {
+        makeMenuBar();
+    }
 
+    @DefaultPosition
+    public Position getPosition() {
+        return CompassPosition.EAST;
+    }
+
+    @OnStartup
+    public void onStartup(final PlaceRequest place) {
+        this.place = place;
+
+        configurationParameters = new HashMap<String, String>();
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return constants.ConfigurationPanel();
+    }
+
+    @WorkbenchPartView
+    public UberView<CMISConfigurationPresenter> getView() {
+        return view;
+    }
+
+    public void refreshConfigurationParameters() {
+        dataServices.call(
+                new RemoteCallback<Map<String, String>>() {
+                    @Override
+                    public void callback(Map<String, String> parameters) {
+                        view.getWSACLTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_ACL_SERVICE));
+                        view.getWSDiscoveryTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_DISCOVERY_SERVICE));
+                        view.getWSMultifilingTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_MULTIFILING_SERVICE));
+                        view.getWSNavigationTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_NAVIGATION_SERVICE));
+                        view.getWSObjectTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_OBJECT_SERVICE));
+                        view.getWSPolicyTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_POLICY_SERVICE));
+                        view.getWSRelationshipTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_RELATIONSHIP_SERVICE));
+                        view.getWSRepositoryTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_REPOSITORY_SERVICE));
+                        view.getWSVersioningTextBox().setText(parameters.get(SessionParameter.WEBSERVICES_VERSIONING_SERVICE));
+                        view.getRepositoryIDTextBox().setText(parameters.get(SessionParameter.REPOSITORY_ID));
+                        view.getUserTextBox().setText(parameters.get(SessionParameter.USER));
+                        view.getPasswordTextBox().setText(parameters.get(SessionParameter.PASSWORD));
+                    }
+                },
+                new DefaultErrorCallback()
+        ).getConfigurationParameters();
+    }
+
+    @OnOpen
+    public void onOpen() {
+        WorkbenchSplitLayoutPanel splitPanel = (WorkbenchSplitLayoutPanel) view
+                .asWidget().getParent().getParent().getParent().getParent()
+                .getParent().getParent().getParent().getParent().getParent()
+                .getParent().getParent();
+        splitPanel.setWidgetMinSize(splitPanel.getWidget(0), 500);
+        refreshConfigurationParameters();
+    }
+
+    public void configureParameters() {
+        HashMap<String, String> parameters = new HashMap<String, String>();
+        parameters.put(SessionParameter.WEBSERVICES_ACL_SERVICE, view.getWSACLTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_DISCOVERY_SERVICE, view.getWSDiscoveryTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_MULTIFILING_SERVICE, view.getWSMultifilingTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_NAVIGATION_SERVICE, view.getWSNavigationTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_OBJECT_SERVICE, view.getWSObjectTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_POLICY_SERVICE, view.getWSPolicyTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_RELATIONSHIP_SERVICE, view.getWSRelationshipTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_REPOSITORY_SERVICE, view.getWSRepositoryTextBox().getText());
+        parameters.put(SessionParameter.WEBSERVICES_VERSIONING_SERVICE, view.getWSVersioningTextBox().getText());
+        parameters.put(SessionParameter.REPOSITORY_ID, view.getRepositoryIDTextBox().getText());
+        parameters.put(SessionParameter.USER, view.getUserTextBox().getText());
+        parameters.put(SessionParameter.PASSWORD, view.getPasswordTextBox().getText());
+
+        dataServices.call(
+                new RemoteCallback<Long>() {
+                    @Override
+                    public void callback(Long taskId) {
+                        view.displayNotification("Updated", NotificationType.SUCCESS);
+                    }
+                },
+                new DefaultErrorCallback()
+        ).setConfigurationParameters(parameters);
+    }
+
+    public void testConnection() {
+        dataServices.call(
+                new RemoteCallback<Boolean>() {
+                    @Override
+                    public void callback(Boolean result) {
+                        if (result) {
+                            view.displayNotification("Connection Successfull", NotificationType.SUCCESS);
+                        } else {
+                            view.displayNotification("Connection Failed", NotificationType.ERROR);
+                        }
+                    }
+                },
+                new DefaultErrorCallback()
+        ).testConnection();
+    }
+
+    @WorkbenchMenu
+    public Menus getMenus() {
+        return menus;
+    }
+
+    private void makeMenuBar() {
+        menus = MenuFactory.newTopLevelMenu(constants.Refresh())
+                .respondsWith(new Command() {
+                    @Override
+                    public void execute() {
+                        refreshConfigurationParameters();
+                        view.displayNotification("Refresh complete.");
+                    }
+                }).endMenu().build();
+
+    }
+
+    private List<MenuItem> getOptions() {
+        return null;
+    }
 }

--- a/jbpm-console-ng-documents/jbpm-console-ng-documents-client/src/main/java/org/jbpm/console/ng/dm/client/document/details/DocumentDetailsPresenter.java
+++ b/jbpm-console-ng-documents/jbpm-console-ng-documents-client/src/main/java/org/jbpm/console/ng/dm/client/document/details/DocumentDetailsPresenter.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jbpm.console.ng.dm.client.document.details;
 
-import java.util.List;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -25,9 +23,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HTML;
 import org.gwtbootstrap3.client.ui.Button;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.dm.client.i18n.Constants;
 import org.jbpm.console.ng.dm.model.CMSContentSummary;
@@ -41,198 +37,109 @@ import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.client.workbench.widgets.split.WorkbenchSplitLayoutPanel;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
-import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
 @WorkbenchScreen(identifier = "Document Details")
 public class DocumentDetailsPresenter {
 
-	private PlaceRequest place;
+    private PlaceRequest place;
 
-	public interface DocumentDetailsView extends
-			UberView<DocumentDetailsPresenter> {
+    public interface DocumentDetailsView extends
+            UberView<DocumentDetailsPresenter> {
 
-		void displayNotification(String text);
+        void displayNotification(String text);
 
-		HTML getDocumentNameText();
+        HTML getDocumentNameText();
 
-		HTML getDocumentIdText();
+        HTML getDocumentIdText();
 
-		Button getOpenDocumentButton();
-	}
+        Button getOpenDocumentButton();
+    }
 
-	private Menus menus;
+    private Menus menus;
 
-	private static String linkURL = "http://127.0.0.1:8888/documentview"; // TODO
-																			// not
-																			// hardcoded
-																			// please!
+    private static String linkURL = "http://127.0.0.1:8888/documentview"; // TODO not hardcoded please!
 
-	@Inject
-	private PlaceManager placeManager;
-	
-	private Constants constants = GWT.create(Constants.class);
+    @Inject
+    private PlaceManager placeManager;
 
-	@Inject
-	private DocumentDetailsView view;
+    private Constants constants = GWT.create(Constants.class);
 
-	@Inject
-	private Caller<DocumentServiceEntryPoint> dataServices;
+    @Inject
+    private DocumentDetailsView view;
 
-	private CMSContentSummary document;
+    @Inject
+    private Caller<DocumentServiceEntryPoint> dataServices;
 
-	public DocumentDetailsPresenter() {
-		makeMenuBar();
-	}
+    private CMSContentSummary document;
 
-	@DefaultPosition
-	public Position getPosition() {
-		return CompassPosition.EAST;
-	}
+    public DocumentDetailsPresenter() {
+    }
 
-	@OnStartup
-	public void onStartup(final PlaceRequest place) {
-		this.place = place;
-	}
+    @DefaultPosition
+    public Position getPosition() {
+        return CompassPosition.EAST;
+    }
 
-	@WorkbenchPartTitle
-	public String getTitle() {
-		return "Document Details";
-	}
+    @OnStartup
+    public void onStartup(final PlaceRequest place) {
+        this.place = place;
+    }
 
-	@WorkbenchPartView
-	public UberView<DocumentDetailsPresenter> getView() {
-		return view;
-	}
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "Document Details";
+    }
 
-	private void changeStyleRow(String processDefName, String processDefVersion) {
-		// processDefStyleEvent.fire( new ProcessDefStyleEvent( processDefName,
-		// processDefVersion ) );
-	}
+    @WorkbenchPartView
+    public UberView<DocumentDetailsPresenter> getView() {
+        return view;
+    }
 
-	public void refreshProcessDef(final String documentId) {
-		dataServices.call(new RemoteCallback<CMSContentSummary>() {
-			@Override
-			public void callback(CMSContentSummary content) {
-				document = content;
-				view.getDocumentIdText().setText(content.getId());
-				view.getDocumentNameText().setText(content.getName());
-			}
-		}, new ErrorCallback<Message>() {
-			@Override
-			public boolean error(Message message, Throwable throwable) {
-				org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-				return true;
-			}
-		}).getDocument(documentId);
-	}
+    public void refreshProcessDef(final String documentId) {
+        dataServices.call(
+                new RemoteCallback<CMSContentSummary>() {
+                    @Override
+                    public void callback(CMSContentSummary content) {
+                        document = content;
+                        view.getDocumentIdText().setText(content.getId());
+                        view.getDocumentNameText().setText(content.getName());
+                    }
+                },
+                new DefaultErrorCallback()
+        ).getDocument(documentId);
+    }
 
-	@OnOpen
-	public void onOpen() {
-		WorkbenchSplitLayoutPanel splitPanel = (WorkbenchSplitLayoutPanel) view
-				.asWidget().getParent().getParent().getParent().getParent()
-				.getParent().getParent().getParent().getParent().getParent()
-				.getParent().getParent();
-		splitPanel.setWidgetMinSize(splitPanel.getWidget(0), 500);
-	}
+    @OnOpen
+    public void onOpen() {
+        WorkbenchSplitLayoutPanel splitPanel = (WorkbenchSplitLayoutPanel) view
+                .asWidget().getParent().getParent().getParent().getParent()
+                .getParent().getParent().getParent().getParent().getParent()
+                .getParent().getParent();
+        splitPanel.setWidgetMinSize(splitPanel.getWidget(0), 500);
+    }
 
-	public void onDocumentDefSelectionEvent(
-			@Observes DocumentDefSelectionEvent event) {
-		refreshProcessDef(event.getDocumentId());
-	}
+    public void onDocumentDefSelectionEvent(@Observes DocumentDefSelectionEvent event) {
+        refreshProcessDef(event.getDocumentId());
+    }
 
-	public void downloadDocument() {
-		if (document != null) {
-			Window.open(linkURL + "?documentId=" + document.getId()
-					+ "&documentName=" + document.getName(),
-					"_blank", "");
-		}
-	}
+    public void downloadDocument() {
+        if (document != null) {
+            Window.open(linkURL + "?documentId=" + document.getId()
+                    + "&documentName=" + document.getName(),
+                    "_blank", "");
+        }
+    }
 
-	@WorkbenchMenu
-	public Menus getMenus() {
-		return menus;
-	}
-
-	private void makeMenuBar() {
-		// menus = MenuFactory
-		// .newTopLevelMenu( constants.New_Instance()).respondsWith(new
-		// Command() {
-		// @Override
-		// public void execute() {
-		// PlaceRequest placeRequestImpl = new DefaultPlaceRequest(
-		// "Form Display Popup" );
-		// placeRequestImpl.addParameter( "processId",
-		// view.getProcessIdText().getText() );
-		// placeRequestImpl.addParameter( "domainId",
-		// view.getDeploymentIdText().getText() );
-		// placeRequestImpl.addParameter( "processName",
-		// view.getProcessNameText().getText() );
-		// placeManager.goTo( placeRequestImpl );
-		// }
-		// }).endMenu()
-		// .newTopLevelMenu( constants.Options())
-		// .withItems(getOptions())
-		// .endMenu()
-		// .newTopLevelMenu( constants.Refresh() )
-		// .respondsWith( new Command() {
-		// @Override
-		// public void execute() {
-		// refreshProcessDef( view.getDeploymentIdText().getText(),
-		// view.getProcessNameText().getText() );
-		// view.displayNotification(
-		// constants.Process_Definition_Details_Refreshed() );
-		// }
-		// } )
-		// .endMenu().build();
-
-	}
-
-	private List<MenuItem> getOptions() {
-		// List<MenuItem> menuItems = new ArrayList<MenuItem>(2);
-		//
-		// menuItems.add( MenuFactory.newSimpleItem(
-		// constants.View_Process_Model()).respondsWith( new Command() {
-		// @Override
-		// public void execute() {
-		// PlaceRequest placeRequestImpl = new DefaultPlaceRequest( "Designer"
-		// );
-		//
-		// // if ( view.getEncodedProcessSource() != null ) {
-		// placeRequestImpl.addParameter( "readOnly", "true" );
-		// //placeRequestImpl.addParameter( "encodedProcessSource",
-		// view.getEncodedProcessSource() );
-		// placeRequestImpl.addParameter("processId",
-		// view.getProcessIdText().getText());
-		// placeRequestImpl.addParameter("deploymentId",
-		// view.getDeploymentIdText().getText());
-		//
-		// //}
-		// placeManager.goTo( view.getProcessAssetPath(), placeRequestImpl );
-		// }
-		// } ).endMenu().build().getItems().get( 0 ) );
-		//
-		// menuItems.add( MenuFactory.newSimpleItem(
-		// constants.View_Process_Instances()).respondsWith( new Command() {
-		// @Override
-		// public void execute() {
-		// PlaceRequest placeRequestImpl = new DefaultPlaceRequest(
-		// "Process Instances" );
-		// placeRequestImpl.addParameter( "processName",
-		// view.getProcessNameText().getText() );
-		// placeManager.goTo( placeRequestImpl );
-		// }
-		// } ).endMenu().build().getItems().get( 0 ) );
-		//
-		//
-		// return menuItems;
-		return null;
-	}
-
+    @WorkbenchMenu
+    public Menus getMenus() {
+        return menus;
+    }
 }

--- a/jbpm-console-ng-human-tasks-admin/jbpm-console-ng-human-tasks-admin-client/src/main/java/org/jbpm/console/ng/ht/admin/client/editors/settings/TaskAdminSettingsPresenter.java
+++ b/jbpm-console-ng-human-tasks-admin/jbpm-console-ng-human-tasks-admin-client/src/main/java/org/jbpm/console/ng/ht/admin/client/editors/settings/TaskAdminSettingsPresenter.java
@@ -19,12 +19,9 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.GWT;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.ht.admin.client.i18n.Constants;
 import org.jbpm.console.ng.ht.admin.service.TaskServiceAdminEntryPoint;
@@ -32,7 +29,7 @@ import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.UberView;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
@@ -83,24 +80,19 @@ public class TaskAdminSettingsPresenter {
     }
 
     public void generateMockTasks(String userName, int amountOfTasks) {
-        taskAdminServices.call(new RemoteCallback<Long>() {
-            @Override
-            public void callback(Long taskId) {
-                view.displayNotification(constants.TaskSuccessfullyCreated());
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error(Message message, Throwable throwable) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        }).generateMockTasks(userName, amountOfTasks);
-
+        taskAdminServices.call(
+                new RemoteCallback<Long>() {
+                    @Override
+                    public void callback(Long taskId) {
+                        view.displayNotification(constants.TaskSuccessfullyCreated());
+                    }
+                },
+                new DefaultErrorCallback()
+        ).generateMockTasks(userName, amountOfTasks);
     }
 
     @OnOpen
     public void onOpen() {
         view.getUserNameText().setFocus(true);
-
     }
 }

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/AbstractTasksListGridPresenter.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/AbstractTasksListGridPresenter.java
@@ -38,9 +38,7 @@ import org.dashbuilder.dataset.filter.CoreFunctionType;
 import org.dashbuilder.dataset.filter.DataSetFilter;
 import org.dashbuilder.dataset.filter.FilterFactory;
 import org.dashbuilder.dataset.sort.SortOrder;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.security.shared.api.Group;
 import org.jboss.errai.security.shared.api.identity.User;
@@ -65,6 +63,7 @@ import org.uberfire.workbench.model.menu.Menus;
 
 import static org.dashbuilder.dataset.filter.FilterFactory.*;
 import static org.jbpm.console.ng.ht.model.TaskDataSetConstants.*;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 
 public abstract class AbstractTasksListGridPresenter extends AbstractScreenListPresenter<TaskSummary> {
 
@@ -383,41 +382,30 @@ public abstract class AbstractTasksListGridPresenter extends AbstractScreenListP
         return view;
     }
 
-    public void releaseTask(final Long taskId,
-                            final String userId) {
-        taskOperationsService.call(new RemoteCallback<Void>() {
-            @Override
-            public void callback(Void nothing) {
-                view.displayNotification(Constants.INSTANCE.TaskReleased(String.valueOf(taskId)));
-                refreshGrid();
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error(Message message,
-                                 Throwable throwable) {
-                errorPopup.showMessage(Constants.INSTANCE.UnexpectedError(throwable.getMessage()));
-                return true;
-            }
-        }).release(taskId, userId);
+    public void releaseTask(final Long taskId, final String userId) {
+        taskOperationsService.call(
+                new RemoteCallback<Void>() {
+                    @Override
+                    public void callback(Void nothing) {
+                        view.displayNotification(Constants.INSTANCE.TaskReleased(String.valueOf(taskId)));
+                        refreshGrid();
+                    }
+                },
+                new DefaultErrorCallback()
+        ).release(taskId, userId);
     }
 
-    public void claimTask(final Long taskId,
-                          final String userId,
-                          final String deploymentId) {
-        taskOperationsService.call(new RemoteCallback<Void>() {
-            @Override
-            public void callback(Void nothing) {
-                view.displayNotification(Constants.INSTANCE.TaskClaimed(String.valueOf(taskId)));
-                refreshGrid();
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error(Message message,
-                                 Throwable throwable) {
-                errorPopup.showMessage(Constants.INSTANCE.UnexpectedError(throwable.getMessage()));
-                return true;
-            }
-        }).claim(taskId, userId, deploymentId);
+    public void claimTask(final Long taskId, final String userId, final String deploymentId) {
+        taskOperationsService.call(
+                new RemoteCallback<Void>() {
+                    @Override
+                    public void callback(Void nothing) {
+                        view.displayNotification(Constants.INSTANCE.TaskClaimed(String.valueOf(taskId)));
+                        refreshGrid();
+                    }
+                },
+                new DefaultErrorCallback()
+        ).claim(taskId, userId, deploymentId);
     }
 
     @Override

--- a/jbpm-console-ng-process-runtime-admin/jbpm-console-ng-process-runtime-admin-client/src/main/java/org/jbpm/console/ng/pr/admin/client/editors/settings/ProcessAdminSettingsPresenter.java
+++ b/jbpm-console-ng-process-runtime-admin/jbpm-console-ng-process-runtime-admin-client/src/main/java/org/jbpm/console/ng/pr/admin/client/editors/settings/ProcessAdminSettingsPresenter.java
@@ -22,9 +22,7 @@ import javax.inject.Inject;
 import com.google.gwt.core.client.GWT;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.pr.admin.client.i18n.ProcessAdminConstants;
 
@@ -34,7 +32,7 @@ import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 
 import org.uberfire.client.mvp.UberView;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
@@ -89,25 +87,20 @@ public class ProcessAdminSettingsPresenter {
     }
 
 
-    public void generateMockInstances(String deployId,String processId, int amountOfTasks) {
-        instancesAdminServices.call(new RemoteCallback<Long>() {
-            @Override
-            public void callback(Long taskId) {
-                view.displayNotification(constants.ProcessInstancesSuccessfullyCreated());
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error(Message message, Throwable throwable) {
-                ErrorPopup.showMessage(constants.UnexpectedError(throwable.getMessage()));
-                return true;
-            }
-        }).generateMockInstances( deployId, processId, amountOfTasks );
-
+    public void generateMockInstances(String deployId, String processId, int amountOfTasks) {
+        instancesAdminServices.call(
+                new RemoteCallback<Long>() {
+                    @Override
+                    public void callback(Long taskId) {
+                        view.displayNotification(constants.ProcessInstancesSuccessfullyCreated());
+                    }
+                },
+                new DefaultErrorCallback()
+        ).generateMockInstances(deployId, processId, amountOfTasks);
     }
 
     @OnOpen
     public void onOpen() {
         view.getDeploymentIdText().setFocus( true );
-
     }
 }

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/definition/details/advance/AdvancedViewProcessDefDetailsPresenter.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/definition/details/advance/AdvancedViewProcessDefDetailsPresenter.java
@@ -22,9 +22,7 @@ import java.util.Map;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.bd.service.DataServiceEntryPoint;
 import org.jbpm.console.ng.ga.model.process.DummyProcessPath;
@@ -36,11 +34,11 @@ import org.jbpm.console.ng.pr.model.ProcessSummary;
 import org.jbpm.console.ng.pr.service.ProcessDefinitionService;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.VFSService;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.IsWidget;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 
 @Dependent
 public class AdvancedViewProcessDefDetailsPresenter extends
@@ -87,209 +85,177 @@ public class AdvancedViewProcessDefDetailsPresenter extends
         view.getDeploymentIdText().setText( deploymentId );
     }
 
-    private void refreshServiceTasks( final String deploymentId, final String processId ) {
-        dataServices.call( new RemoteCallback<Map<String, String>>() {
-
-            @Override
-            public void callback( Map<String, String> services ) {
-                view.getProcessServicesListBox().setText( "" );
-                SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
-                if (services.keySet().isEmpty()) {
-                    safeHtmlBuilder.appendEscaped(constants.NoServicesRequiredForThisProcess());
-                    view.getProcessServicesListBox().setStyleName( "muted" );
-                    view.getProcessServicesListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                } else {
-                    for (String key : services.keySet()) {
-                        safeHtmlBuilder.appendEscapedLines( key + " - "
-                                + services.get( key ) + "\n" );
-                    }
-                    view.getProcessServicesListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                }
-            }
-        }, new ErrorCallback<Message>() {
-
-            @Override
-            public boolean error( Message message, Throwable throwable ) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        } ).getServiceTasks( deploymentId, processId );
-    }
-
-    private void refreshProcessItems( final String deploymentId,
-            final String processId ) {
-        processDefService.call( new RemoteCallback<ProcessSummary>() {
-
-            @Override
-            public void callback( ProcessSummary process ) {
-                if (process != null) {
-                    view.setEncodedProcessSource( process
-                            .getEncodedProcessSource() );
-                    view.getProcessNameText().setText( process.getName() );
-                    if (process.getOriginalPath() != null) {
-                        fileServices.call( new RemoteCallback<Path>() {
-
-                            @Override
-                            public void callback( Path processPath ) {
-                                view.setProcessAssetPath( processPath );
+    private void refreshServiceTasks(final String deploymentId, final String processId) {
+        dataServices.call(
+                new RemoteCallback<Map<String, String>>() {
+                    @Override
+                    public void callback(Map<String, String> services) {
+                        view.getProcessServicesListBox().setText("");
+                        SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
+                        if (services.keySet().isEmpty()) {
+                            safeHtmlBuilder.appendEscaped(constants.NoServicesRequiredForThisProcess());
+                            view.getProcessServicesListBox().setStyleName("muted");
+                            view.getProcessServicesListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        } else {
+                            for (String key : services.keySet()) {
+                                safeHtmlBuilder.appendEscapedLines(key + " - "
+                                        + services.get(key) + "\n");
                             }
-                        } ).get( process.getOriginalPath() );
-                    } else {
-                        view.setProcessAssetPath( new DummyProcessPath( process.getProcessDefId() ) );
+                            view.getProcessServicesListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        }
                     }
-                    changeStyleRow( process.getName(), process.getVersion() );
-                } else {
-                    // set to null to ensure it's clear state
-                    view.setEncodedProcessSource( null );
-                    view.setProcessAssetPath( null );
-                }
-            }
-        }, new ErrorCallback<Message>() {
-
-            @Override
-            public boolean error( Message message, Throwable throwable ) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        } ).getItem( new ProcessDefinitionKey( deploymentId, processId ) );
+                },
+                new DefaultErrorCallback()
+        ).getServiceTasks(deploymentId, processId);
     }
 
-    private void refreshReusableSubProcesses( final String deploymentId, final String processId ) {
-        dataServices.call( new RemoteCallback<Collection<String>>() {
+    private void refreshProcessItems(final String deploymentId,
+            final String processId) {
+        processDefService.call(
+                new RemoteCallback<ProcessSummary>() {
+                    @Override
+                    public void callback(ProcessSummary process) {
+                        if (process != null) {
+                            view.setEncodedProcessSource(process
+                                    .getEncodedProcessSource());
+                            view.getProcessNameText().setText(process.getName());
+                            if (process.getOriginalPath() != null) {
+                                fileServices.call(new RemoteCallback<Path>() {
 
-            @Override
-            public void callback( Collection<String> subprocesses ) {
-                view.getSubprocessListBox().setText( "" );
-                SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
-                if (subprocesses.isEmpty()) {
-                    safeHtmlBuilder.appendEscapedLines(constants.NoSubprocessesRequiredByThisProcess());
-                    view.getSubprocessListBox().setStyleName( "muted" );
-                    view.getSubprocessListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                } else {
-                    for (String key : subprocesses) {
-                        safeHtmlBuilder.appendEscapedLines( key + "\n" );
+                                    @Override
+                                    public void callback(Path processPath) {
+                                        view.setProcessAssetPath(processPath);
+                                    }
+                                }).get(process.getOriginalPath());
+                            } else {
+                                view.setProcessAssetPath(new DummyProcessPath(process.getProcessDefId()));
+                            }
+                            changeStyleRow(process.getName(), process.getVersion());
+                        } else {
+                            // set to null to ensure it's clear state
+                            view.setEncodedProcessSource(null);
+                            view.setProcessAssetPath(null);
+                        }
                     }
-                    view.getSubprocessListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                }
-            }
-        }, new ErrorCallback<Message>() {
-
-            @Override
-            public boolean error( Message message, Throwable throwable ) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        } ).getReusableSubProcesses( deploymentId, processId );
+                },
+                new DefaultErrorCallback()
+        ).getItem(new ProcessDefinitionKey(deploymentId, processId));
     }
 
-    private void refreshRequiredInputData( final String deploymentId,
-            final String processId ) {
-        dataServices.call( new RemoteCallback<Map<String, String>>() {
-
-            @Override
-            public void callback( Map<String, String> inputs ) {
-                view.getProcessDataListBox().setText( "" );
-                SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
-                if (inputs.keySet().isEmpty()) {
-                    safeHtmlBuilder.appendEscapedLines(constants.NoProcessVariablesDefinedForThisProcess());
-                    view.getProcessDataListBox().setStyleName( "muted" );
-                    view.getProcessDataListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                } else {
-                    for (String key : inputs.keySet()) {
-                        safeHtmlBuilder.appendEscapedLines( key + " - "
-                                + inputs.get( key ) + "\n" );
+    private void refreshReusableSubProcesses(final String deploymentId, final String processId) {
+        dataServices.call(
+                new RemoteCallback<Collection<String>>() {
+                    @Override
+                    public void callback(Collection<String> subprocesses) {
+                        view.getSubprocessListBox().setText("");
+                        SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
+                        if (subprocesses.isEmpty()) {
+                            safeHtmlBuilder.appendEscapedLines(constants.NoSubprocessesRequiredByThisProcess());
+                            view.getSubprocessListBox().setStyleName("muted");
+                            view.getSubprocessListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        } else {
+                            for (String key : subprocesses) {
+                                safeHtmlBuilder.appendEscapedLines(key + "\n");
+                            }
+                            view.getSubprocessListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        }
                     }
-                    view.getProcessDataListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                }
-            }
-        }, new ErrorCallback<Message>() {
-
-            @Override
-            public boolean error( Message message, Throwable throwable ) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        } ).getRequiredInputData( deploymentId, processId );
+                },
+                new DefaultErrorCallback()
+        ).getReusableSubProcesses(deploymentId, processId);
     }
 
-    private void refreshAssociatedEntities( final String deploymentId, final String processId ) {
+    private void refreshRequiredInputData(final String deploymentId, final String processId) {
+        dataServices.call(
+                new RemoteCallback<Map<String, String>>() {
+                    @Override
+                    public void callback(Map<String, String> inputs) {
+                        view.getProcessDataListBox().setText("");
+                        SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
+                        if (inputs.keySet().isEmpty()) {
+                            safeHtmlBuilder.appendEscapedLines(constants.NoProcessVariablesDefinedForThisProcess());
+                            view.getProcessDataListBox().setStyleName("muted");
+                            view.getProcessDataListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        } else {
+                            for (String key : inputs.keySet()) {
+                                safeHtmlBuilder.appendEscapedLines(key + " - "
+                                        + inputs.get(key) + "\n");
+                            }
+                            view.getProcessDataListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        }
+                    }
+                },
+                new DefaultErrorCallback()
+        ).getRequiredInputData(deploymentId, processId);
+    }
+
+    private void refreshAssociatedEntities(final String deploymentId, final String processId) {
         dataServices.call(
                 new RemoteCallback<Map<String, Collection<String>>>() {
-
                     @Override
-                    public void callback(
-                            Map<String, Collection<String>> entities ) {
-                        view.getUsersGroupsListBox().setText( "" );
+                    public void callback(Map<String, Collection<String>> entities) {
+                        view.getUsersGroupsListBox().setText("");
                         SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
                         if (entities.keySet().isEmpty()) {
                             safeHtmlBuilder
-                                    .appendEscapedLines(constants.NoUserOrGroupUsedInThisProcess());
-                            view.getUsersGroupsListBox().setStyleName( "muted" );
+                            .appendEscapedLines(constants.NoUserOrGroupUsedInThisProcess());
+                            view.getUsersGroupsListBox().setStyleName("muted");
                             view.getUsersGroupsListBox().setHTML(
-                                    safeHtmlBuilder.toSafeHtml() );
+                                    safeHtmlBuilder.toSafeHtml());
                         } else {
                             for (String key : entities.keySet()) {
                                 StringBuffer names = new StringBuffer();
                                 Collection<String> entityNames = entities
-                                        .get( key );
+                                .get(key);
                                 if (entityNames != null) {
                                     for (String entity : entityNames) {
-                                        names.append( "'" + entity + "' " );
+                                        names.append("'" + entity + "' ");
                                     }
                                 }
-                                safeHtmlBuilder.appendEscapedLines( names
-                                        + " - " + key + "\n" );
+                                safeHtmlBuilder.appendEscapedLines(names
+                                        + " - " + key + "\n");
                             }
                             view.getUsersGroupsListBox().setHTML(
-                                    safeHtmlBuilder.toSafeHtml() );
+                                    safeHtmlBuilder.toSafeHtml());
                         }
                     }
-                }, new ErrorCallback<Message>() {
-
-                    @Override
-                    public boolean error( Message message, Throwable throwable ) {
-                        ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                        return true;
-                    }
-                } ).getAssociatedEntities( deploymentId, processId );
+                },
+                new DefaultErrorCallback()
+        ).getAssociatedEntities(deploymentId, processId);
     }
 
-    private void refreshTaskDef( final String deploymentId, final String processId ) {
-        dataServices.call( new RemoteCallback<List<TaskDefSummary>>() {
+    private void refreshTaskDef(final String deploymentId, final String processId) {
+        dataServices.call(
+                new RemoteCallback<List<TaskDefSummary>>() {
 
-            @Override
-            public void callback( List<TaskDefSummary> tasks ) {
-                view.getNroOfHumanTasksText().setText(
-                        String.valueOf( tasks.size() ) );
-                view.getHumanTasksListBox().setText( "" );
-                SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
-                if (tasks.isEmpty()) {
-                    safeHtmlBuilder.appendEscapedLines(constants.NoUserTasksDefinedInThisProcess());
-                    view.getHumanTasksListBox().setStyleName( "muted" );
-                    view.getHumanTasksListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                } else {
-                    for (TaskDefSummary t : tasks) {
-                        safeHtmlBuilder.appendEscapedLines( t.getName() + "\n" );
+                    @Override
+                    public void callback(List<TaskDefSummary> tasks) {
+                        view.getNroOfHumanTasksText().setText(
+                                String.valueOf(tasks.size()));
+                        view.getHumanTasksListBox().setText("");
+                        SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
+                        if (tasks.isEmpty()) {
+                            safeHtmlBuilder.appendEscapedLines(constants.NoUserTasksDefinedInThisProcess());
+                            view.getHumanTasksListBox().setStyleName("muted");
+                            view.getHumanTasksListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        } else {
+                            for (TaskDefSummary t : tasks) {
+                                safeHtmlBuilder.appendEscapedLines(t.getName() + "\n");
+                            }
+                            view.getHumanTasksListBox().setHTML(
+                                    safeHtmlBuilder.toSafeHtml());
+                        }
                     }
-                    view.getHumanTasksListBox().setHTML(
-                            safeHtmlBuilder.toSafeHtml() );
-                }
-            }
-        }, new ErrorCallback<Message>() {
-
-            @Override
-            public boolean error( Message message, Throwable throwable ) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        } ).getAllTasksDef( deploymentId, processId );
+                },
+                new DefaultErrorCallback()
+        ).getAllTasksDef(deploymentId, processId);
     }
 
     @Override

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/definition/details/basic/BasicProcessDefDetailsPresenter.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/definition/details/basic/BasicProcessDefDetailsPresenter.java
@@ -18,9 +18,7 @@ package org.jbpm.console.ng.pr.client.editors.definition.details.basic;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.ga.model.process.DummyProcessPath;
 import org.jbpm.console.ng.pr.client.editors.definition.details.BaseProcessDefDetailsPresenter;
@@ -30,9 +28,9 @@ import org.jbpm.console.ng.pr.model.ProcessSummary;
 import org.jbpm.console.ng.pr.service.ProcessDefinitionService;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.VFSService;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 
 @Dependent
 public class BasicProcessDefDetailsPresenter extends BaseProcessDefDetailsPresenter {
@@ -64,48 +62,39 @@ public class BasicProcessDefDetailsPresenter extends BaseProcessDefDetailsPresen
         view.getDeploymentIdText().setText( currentDeploymentId );
     }
 
-    private void refreshProcessItems( final String deploymentId, final String processId ) {
-
-        processDefService.call( new RemoteCallback<ProcessSummary>() {
-
-            @Override
-            public void callback( ProcessSummary process ) {
-                if (process != null) {
-                    view.setEncodedProcessSource( process.getEncodedProcessSource() );
-                    view.getProcessNameText().setText( process.getName() );
-                    if (process.getOriginalPath() != null) {
-
-                        fileServices.call( new RemoteCallback<Path>() {
-
-                            @Override
-                            public void callback( Path processPath ) {
-                                view.setProcessAssetPath( processPath );
+    private void refreshProcessItems(final String deploymentId, final String processId) {
+        processDefService.call(
+                new RemoteCallback<ProcessSummary>() {
+                    @Override
+                    public void callback(ProcessSummary process) {
+                        if (process != null) {
+                            view.setEncodedProcessSource(process.getEncodedProcessSource());
+                            view.getProcessNameText().setText(process.getName());
+                            if (process.getOriginalPath() != null) {
+                                fileServices.call(new RemoteCallback<Path>() {
+                                    @Override
+                                    public void callback(Path processPath) {
+                                        view.setProcessAssetPath(processPath);
+                                    }
+                                }).get(process.getOriginalPath());
+                            } else {
+                                view.setProcessAssetPath(new DummyProcessPath(process
+                                                .getProcessDefId()));
                             }
-                        } ).get( process.getOriginalPath() );
-                    } else {
-                        view.setProcessAssetPath( new DummyProcessPath( process
-                                .getProcessDefId() ) );
+                            changeStyleRow(process.getName(), process.getVersion());
+                        } else {
+                            // set to null to ensure it's clear state
+                            view.setEncodedProcessSource(null);
+                            view.setProcessAssetPath(null);
+                        }
                     }
-                    changeStyleRow( process.getName(), process.getVersion() );
-                } else {
-                    // set to null to ensure it's clear state
-                    view.setEncodedProcessSource( null );
-                    view.setProcessAssetPath( null );
-                }
-            }
-        }, new ErrorCallback<Message>() {
-
-            @Override
-            public boolean error( Message message, Throwable throwable ) {
-                ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                return true;
-            }
-        } ).getItem( new ProcessDefinitionKey( deploymentId, processId ) );
+                },
+                new DefaultErrorCallback()
+        ).getItem(new ProcessDefinitionKey(deploymentId, processId));
     }
 
     @Override
     protected void refreshProcessDef( String deploymentId, String processId ) {
         refreshProcessItems( deploymentId, processId );
     }
-
 }

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/list/variables/dash/DataSetProcessInstanceWithVariablesListPresenter.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/list/variables/dash/DataSetProcessInstanceWithVariablesListPresenter.java
@@ -34,9 +34,7 @@ import org.dashbuilder.dataset.filter.CoreFunctionFilter;
 import org.dashbuilder.dataset.filter.CoreFunctionType;
 import org.dashbuilder.dataset.filter.DataSetFilter;
 import org.dashbuilder.dataset.sort.SortOrder;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.bd.service.KieSessionEntryPoint;
 import org.jbpm.console.ng.df.client.filter.FilterSettings;
@@ -63,7 +61,6 @@ import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.ext.widgets.common.client.menu.RefreshMenuBuilder;
 import org.uberfire.ext.widgets.common.client.menu.RefreshSelectorMenuBuilder;
 import org.uberfire.lifecycle.OnFocus;
@@ -78,6 +75,7 @@ import org.uberfire.workbench.model.menu.Menus;
 
 import static org.dashbuilder.dataset.filter.FilterFactory.*;
 import static org.jbpm.console.ng.pr.model.ProcessInstanceDataSetConstants.*;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 
 @Dependent
 @WorkbenchScreen( identifier = DataSetProcessInstanceWithVariablesListPresenter.SCREEN_ID)
@@ -375,36 +373,28 @@ public class DataSetProcessInstanceWithVariablesListPresenter extends AbstractSc
         refreshGrid();
     }
 
-    public void abortProcessInstance( long processInstanceId ) {
-        kieSessionServices.call( new RemoteCallback<Void>() {
-            @Override
-            public void callback( Void v ) {
-                refreshGrid();
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error( Message message,
-                                  Throwable throwable ) {
-                ErrorPopup.showMessage(Constants.INSTANCE.UnexpectedError(throwable.getMessage()));
-                return true;
-            }
-        } ).abortProcessInstance( processInstanceId );
+    public void abortProcessInstance(long processInstanceId) {
+        kieSessionServices.call(
+                new RemoteCallback<Void>() {
+                    @Override
+                    public void callback(Void v) {
+                        refreshGrid();
+                    }
+                },
+                new DefaultErrorCallback()
+        ).abortProcessInstance(processInstanceId);
     }
 
-    public void abortProcessInstance( List<Long> processInstanceIds ) {
-        kieSessionServices.call( new RemoteCallback<Void>() {
-            @Override
-            public void callback( Void v ) {
-                refreshGrid();
-            }
-        }, new ErrorCallback<Message>() {
-            @Override
-            public boolean error( Message message,
-                                  Throwable throwable ) {
-                ErrorPopup.showMessage(Constants.INSTANCE.UnexpectedError(throwable.getMessage()));
-                return true;
-            }
-        } ).abortProcessInstances( processInstanceIds );
+    public void abortProcessInstance(List<Long> processInstanceIds) {
+        kieSessionServices.call(
+                new RemoteCallback<Void>() {
+                    @Override
+                    public void callback(Void v) {
+                        refreshGrid();
+                    }
+                },
+                new DefaultErrorCallback()
+        ).abortProcessInstances(processInstanceIds);
     }
 
     public void bulkSignal( List<ProcessInstanceSummary> processInstances ) {

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/signal/ProcessInstanceSignalPresenter.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/signal/ProcessInstanceSignalPresenter.java
@@ -24,19 +24,17 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
-import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.console.ng.bd.service.KieSessionEntryPoint;
 import org.jbpm.console.ng.pr.client.i18n.Constants;
 import org.jbpm.console.ng.pr.model.events.ProcessInstancesUpdateEvent;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchPopup;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberView;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
@@ -97,23 +95,17 @@ public class ProcessInstanceSignalPresenter {
         return view;
     }
 
-    public void signalProcessInstances( List<Long> processInstanceIds ) {
-
-        kieSessionServices.call( new RemoteCallback<Void>() {
-            @Override
-            public void callback( Void v ) {
-                processInstancesUpdatedEvent.fire(new ProcessInstancesUpdateEvent(0L));
-                
-                placeManager.closePlace( place );
-                
-            }
-        }, new ErrorCallback<Message>() {
-             @Override
-             public boolean error( Message message, Throwable throwable ) {
-                 ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                 return true;
-             }
-         } ).signalProcessInstances( processInstanceIds, view.getSignalRefText(), view.getEventText() );
+    public void signalProcessInstances(List<Long> processInstanceIds) {
+        kieSessionServices.call(
+                new RemoteCallback<Void>() {
+                    @Override
+                    public void callback(Void v) {
+                        processInstancesUpdatedEvent.fire(new ProcessInstancesUpdateEvent(0L));
+                        placeManager.closePlace(place);
+                    }
+                },
+                new DefaultErrorCallback()
+        ).signalProcessInstances(processInstanceIds, view.getSignalRefText(), view.getEventText());
     }
 
     @OnOpen
@@ -131,20 +123,16 @@ public class ProcessInstanceSignalPresenter {
         }
     }
 
-    public void getAvailableSignals( long processInstanceId ) {
-        kieSessionServices.call( new RemoteCallback<Collection<String>>() {
-            @Override
-            public void callback( Collection<String> signals ) {
-                view.setAvailableSignals( signals );
+    public void getAvailableSignals(long processInstanceId) {
+        kieSessionServices.call(
+                new RemoteCallback<Collection<String>>() {
+                    @Override
+                    public void callback(Collection<String> signals) {
+                        view.setAvailableSignals(signals);
 
-            }
-        }, new ErrorCallback<Message>() {
-             @Override
-             public boolean error( Message message, Throwable throwable ) {
-                 ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
-                 return true;
-             }
-         } ).getAvailableSignals( processInstanceId );
+                    }
+                },
+                new DefaultErrorCallback()
+        ).getAvailableSignals(processInstanceId);
     }
-
 }


### PR DESCRIPTION
Replace repeated occurrences of the following

    new ErrorCallback<Message>() {
        @Override
        public boolean error( Message message, Throwable throwable ) {
            ErrorPopup.showMessage( constants.UnexpectedError(throwable.getMessage()) );
            return true;
        }
    }

with 'DefaultErrorCallback' from Uberfire extensions which does the same, but with possibly improved error messages.

I limited the scope of code reformatting only to methods containing UF Caller calls, with the exception of the first 2 files - i reformatted these as a whole (in the beginning of PR).
Also removed unused/ commented-out methods from the first 2 files.
@cristianonicolai Could you please review?