### PR TITLE
[DROOLS-1216] exclude commons-logging and use jcl-over-slf4j instead

### DIFF
--- a/jbpm-console-ng-rest/pom.xml
+++ b/jbpm-console-ng-rest/pom.xml
@@ -135,17 +135,19 @@
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for the above excluded 'commons-logging:commons-logging' -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jbpm-console-ng-rest/src/main/java/org/jbpm/console/ng/rest/ProcessImageResourceImpl.java
+++ b/jbpm-console-ng-rest/src/main/java/org/jbpm/console/ng/rest/ProcessImageResourceImpl.java
@@ -22,7 +22,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
 import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.m2repo.backend.server.GuvnorM2Repository;
 import org.jbpm.kie.services.impl.model.ProcessAssetDesc;


### PR DESCRIPTION
Part of an ensemble:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/226
https://github.com/droolsjbpm/drools/pull/815
https://github.com/droolsjbpm/optaplanner/pull/200
https://github.com/droolsjbpm/jbpm/pull/487
https://github.com/droolsjbpm/droolsjbpm-integration/pull/509
https://github.com/droolsjbpm/kie-uberfire-extensions/pull/29
https://github.com/droolsjbpm/guvnor/pull/328
https://github.com/droolsjbpm/drools-wb/pull/209
https://github.com/droolsjbpm/jbpm-designer/pull/302
https://github.com/droolsjbpm/jbpm-console-ng/pull/432
https://github.com/droolsjbpm/kie-wb-distributions/pull/303
