### PR TITLE
BPMSPL-295 - Higher level of automation when importing custom workItemHandlers from a service repository

### DIFF
--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdater.java
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/main/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdater.java
@@ -18,6 +18,7 @@ package org.jbpm.console.ng.wi.backend.server.dd;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -26,6 +27,7 @@ import javax.inject.Named;
 import org.jbpm.console.ng.wi.dd.model.DeploymentDescriptorModel;
 import org.jbpm.console.ng.wi.dd.model.ItemObjectModel;
 import org.jbpm.console.ng.wi.dd.service.DDEditorService;
+import org.jbpm.designer.notification.DesignerWorkitemInstalledEvent;
 import org.kie.workbench.common.services.shared.project.KieProject;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.uberfire.backend.server.util.Paths;
@@ -47,6 +49,10 @@ public class DDConfigUpdater {
 
     private DDConfigUpdaterHelper configUpdaterHelper;
 
+    private static final String MVEL_PREFIX = "mvel:";
+
+    private static final String REFLECTION_PREFIX = "reflection:";
+
     public DDConfigUpdater() {
     }
     
@@ -63,29 +69,103 @@ public class DDConfigUpdater {
     }
 
     public void processResourceAdd( @Observes final ResourceAddedEvent resourceAddedEvent ) {
-        if ( configUpdaterHelper.isPersistenceFile( resourceAddedEvent.getPath() ) ) {
+        if ( configUpdaterHelper.isPersistenceFile(resourceAddedEvent.getPath()) ) {
             //persistence.xml has been added to current project.
-            updateConfig( projectService.resolveProject( resourceAddedEvent.getPath() ) );
+            updateConfig(projectService.resolveProject(resourceAddedEvent.getPath()));
         }
     }
 
     public void processResourceUpdate( @Observes final ResourceUpdatedEvent resourceUpdatedEvent ) {
-        if ( configUpdaterHelper.isPersistenceFile( resourceUpdatedEvent.getPath() ) ) {
+        if ( configUpdaterHelper.isPersistenceFile(resourceUpdatedEvent.getPath()) ) {
             //persistence.xml has been updated in current project.
-            updateConfig( projectService.resolveProject( resourceUpdatedEvent.getPath() ) );
+            updateConfig(projectService.resolveProject(resourceUpdatedEvent.getPath()));
         }
+    }
+
+    public void processWorkitemInstall( @Observes final DesignerWorkitemInstalledEvent workitemInstalledEvent ) {
+        addWorkItemToConfig(projectService.resolveProject(workitemInstalledEvent.getPath()), workitemInstalledEvent);
+    }
+
+    private void addWorkItemToConfig( final KieProject kieProject, final DesignerWorkitemInstalledEvent workitemInstalledEvent) {
+        Path deploymentDescriptorPath = getDeploymentDescriptorPath( kieProject );
+        if ( ioService.exists(Paths.convert(deploymentDescriptorPath)) ) {
+            DeploymentDescriptorModel descriptorModel = ddEditorService.load( deploymentDescriptorPath );
+
+            if(descriptorModel != null) {
+                if(descriptorModel.getWorkItemHandlers() == null) {
+                    descriptorModel.setWorkItemHandlers(new ArrayList<>());
+                }
+
+                if( isValidWorkitem(workitemInstalledEvent) && !workItemAlreadyInstalled( descriptorModel.getWorkItemHandlers(), workitemInstalledEvent.getName()) ) {
+                    ItemObjectModel itemModel = new ItemObjectModel(workitemInstalledEvent.getName(),
+                            parseWorkitemValue(workitemInstalledEvent.getValue()),
+                            getWorkitemResolver(workitemInstalledEvent.getValue(), workitemInstalledEvent.getResolver()),
+                            null);
+                    descriptorModel.getWorkItemHandlers().add(itemModel);
+
+                    CommentedOption commentedOption = new CommentedOption( "system", null, "Workitem config added by system.", new Date() );
+                    ( ( DDEditorServiceImpl ) ddEditorService ).save(deploymentDescriptorPath, descriptorModel, descriptorModel.getOverview().getMetadata(), commentedOption);
+                }
+            }
+        }
+    }
+
+    public String parseWorkitemValue(String value) {
+        if(value.trim().toLowerCase().startsWith(MVEL_PREFIX)) {
+            return value.trim().substring(MVEL_PREFIX.length()).trim();
+        } else if(value.trim().toLowerCase().startsWith(REFLECTION_PREFIX)) {
+            return value.trim().substring(REFLECTION_PREFIX.length()).trim();
+        } else {
+            return value.trim();
+        }
+    }
+
+    public String getWorkitemResolver(String value, String defaultResolver) {
+        if(value.trim().toLowerCase().startsWith(MVEL_PREFIX)) {
+            return MVEL_PREFIX.substring(0,MVEL_PREFIX.length()-1);
+        } else if(value.trim().toLowerCase().startsWith(REFLECTION_PREFIX)) {
+            return REFLECTION_PREFIX.substring(0,REFLECTION_PREFIX.length()-1);
+        } else {
+            return defaultResolver;
+        }
+    }
+
+    public boolean isValidWorkitem(DesignerWorkitemInstalledEvent workitemInstalledEvent) {
+        return workitemInstalledEvent != null &&
+                workitemInstalledEvent.getName() != null &&
+                workitemInstalledEvent.getName().trim().length() > 0 &&
+                workitemInstalledEvent.getValue() != null &&
+                workitemInstalledEvent.getValue().trim().length() > 0;
+    }
+
+    private boolean workItemAlreadyInstalled(List<ItemObjectModel> workitemHandlers, String name) {
+        if(name == null || name.trim().length() < 1) {
+            return false;
+        }
+
+        for(ItemObjectModel itemObject : workitemHandlers) {
+            if(itemObject != null && itemObject.getName().equals(name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void updateConfig( final KieProject kieProject ) {
 
-        Path deploymentDescriptorPath = PathFactory.newPath( "kie-deployment-descriptor.xml",
-                kieProject.getRootPath().toURI() + "/src/main/resources/META-INF/kie-deployment-descriptor.xml" );
+        Path deploymentDescriptorPath = getDeploymentDescriptorPath( kieProject );
 
-        if ( ioService.exists( Paths.convert( deploymentDescriptorPath ) ) ) {
+        if ( ioService.exists(Paths.convert( deploymentDescriptorPath )) ) {
             //if deployment descriptor exists created, then update it.
             DeploymentDescriptorModel descriptorModel = ddEditorService.load( deploymentDescriptorPath );
             updateMarshallingConfig( descriptorModel, deploymentDescriptorPath, kieProject );
         }
+    }
+
+    private Path getDeploymentDescriptorPath( final KieProject kieProject ) {
+        return PathFactory.newPath( "kie-deployment-descriptor.xml",
+                kieProject.getRootPath().toURI() + "/src/main/resources/META-INF/kie-deployment-descriptor.xml" );
     }
 
     private void updateMarshallingConfig( final DeploymentDescriptorModel descriptorModel,

--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/test/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdaterTest.java
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/test/java/org/jbpm/console/ng/wi/backend/server/dd/DDConfigUpdaterTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.wi.backend.server.dd;
+
+import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.jbpm.console.ng.wi.dd.model.DeploymentDescriptorModel;
+import org.jbpm.console.ng.wi.dd.model.ItemObjectModel;
+import org.jbpm.designer.notification.DesignerWorkitemInstalledEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.workbench.events.ResourceAddedEvent;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DDConfigUpdaterTest {
+
+    private static final String JPA_MARSHALLING_STRATEGY = "org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy";
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private KieProjectService projectService;
+
+    @Mock
+    private DDEditorServiceImpl ddEditorService;
+
+    @Mock
+    private DDConfigUpdaterHelper configUpdaterHelper;
+
+    private DeploymentDescriptorModel model;
+    private DDConfigUpdater ddConfigUpdater;
+
+    @Before
+    public void setup() {
+        model = new DeploymentDescriptorModel();
+        model.setOverview(new Overview());
+        ddConfigUpdater = new DDConfigUpdater(ddEditorService, projectService, ioService, configUpdaterHelper);
+
+        Path rootPath = Mockito.mock(Path.class);
+        when(rootPath.toURI()).thenReturn("default://project");
+        KieProject project = Mockito.mock(KieProject.class);
+        when(project.getRootPath()).thenReturn(rootPath);
+
+        when(ioService.exists(any(org.uberfire.java.nio.file.Path.class))).thenReturn(true);
+        when(configUpdaterHelper.isPersistenceFile(any(Path.class))).thenReturn(true);
+        when(configUpdaterHelper.buildJPAMarshallingStrategyValue(any(KieProject.class))).thenReturn(JPA_MARSHALLING_STRATEGY);
+        when(projectService.resolveProject(any(Path.class))).thenReturn(project);
+        when(ddEditorService.load(any(Path.class))).thenReturn(model);
+    }
+
+    @Test
+    public void testProcessResourceAdd() {
+        ddConfigUpdater.processResourceAdd(new ResourceAddedEvent(Mockito.mock(Path.class), "test resource", Mockito.mock(SessionInfo.class)));
+
+        assertNotNull(model.getMarshallingStrategies());
+        assertEquals(1, model.getMarshallingStrategies().size());
+
+        ItemObjectModel objectModel = model.getMarshallingStrategies().get(0);
+        assertNotNull(objectModel);
+        assertEquals(JPA_MARSHALLING_STRATEGY, objectModel.getValue());
+        assertEquals("mvel", objectModel.getResolver());
+    }
+
+    @Test
+    public void testProcessWorkitemInstall() {
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "new com.myhandlers.MyHandler()", "MyWorkItem", ""));
+
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(1, model.getWorkItemHandlers().size());
+
+        ItemObjectModel objectModel = model.getWorkItemHandlers().get(0);
+        assertNotNull(objectModel);
+        assertEquals("MyWorkItem", objectModel.getName());
+        assertEquals("mvel", objectModel.getResolver());
+        assertEquals("new com.myhandlers.MyHandler()", objectModel.getValue());
+
+
+        // same name -- should not add
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "new com.myhandlers.MyHandler2()", "MyWorkItem", ""));
+
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(1, model.getWorkItemHandlers().size());
+        // make sure the one we have is not this new one
+        assertEquals("new com.myhandlers.MyHandler()", model.getWorkItemHandlers().get(0).getValue());
+
+        // different name - should add
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "reflection", "com.myhandlers.MyHandler", "MyWorkItem2", ""));
+
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(2, model.getWorkItemHandlers().size());
+
+        ItemObjectModel objectModel2 = model.getWorkItemHandlers().get(1);
+        assertNotNull(objectModel2);
+        assertEquals("MyWorkItem2", objectModel2.getName());
+        assertEquals("reflection", objectModel2.getResolver());
+        assertEquals("com.myhandlers.MyHandler", objectModel2.getValue());
+
+        // invalid (no name) - should not add
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "new com.myhandlers.MyHandler3()", "", ""));
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(2, model.getWorkItemHandlers().size());
+
+        // invalid (no handler) - should not add
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "", "MyWorkItem3", ""));
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(2, model.getWorkItemHandlers().size());
+
+        // invalid (no name and handler) - should not add
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "", "", ""));
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(2, model.getWorkItemHandlers().size());
+
+        // test overwritten resolver from value
+        ddConfigUpdater.processWorkitemInstall(new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "reflection", "mvel: new com.myhandlers.MyHandler4()", "MyWorkItem4", ""));
+        assertNotNull(model.getWorkItemHandlers());
+        assertEquals(3, model.getWorkItemHandlers().size());
+
+        ItemObjectModel objectModel3 = model.getWorkItemHandlers().get(2);
+        assertNotNull(objectModel3);
+        assertEquals("MyWorkItem4", objectModel3.getName());
+        assertEquals("mvel", objectModel3.getResolver());
+        assertEquals("new com.myhandlers.MyHandler4()", objectModel3.getValue());
+
+    }
+
+    @Test
+    public void testIsValidWorkitem() {
+        assertFalse(ddConfigUpdater.isValidWorkitem(null));
+
+        assertFalse(ddConfigUpdater.isValidWorkitem(
+                new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "", "", "", "")
+        ));
+
+        assertFalse(ddConfigUpdater.isValidWorkitem(
+                new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "", "", "")
+        ));
+
+        assertFalse(ddConfigUpdater.isValidWorkitem(
+                new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "new com.myhandlers.MyHandler()", "", "")
+        ));
+
+        assertFalse(ddConfigUpdater.isValidWorkitem(
+                new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "", "MyHandler", "")
+        ));
+
+        assertTrue(ddConfigUpdater.isValidWorkitem(
+                new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "mvel", "new com.myhandlers.MyHandler()", "MyHandler", "")
+        ));
+
+        assertTrue(ddConfigUpdater.isValidWorkitem(
+                new DesignerWorkitemInstalledEvent(Mockito.mock(Path.class), "", "mvel: new com.myhandlers.MyHandler()", "MyHandler", "")
+        ));
+    }
+
+    @Test
+    public void testParseWorkitemValue() {
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("new com.myhandlers.MyHandler()"));
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("  new com.myhandlers.MyHandler()"));
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("new com.myhandlers.MyHandler()   "));
+
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("mvel: new com.myhandlers.MyHandler()"));
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("reflection: new com.myhandlers.MyHandler()"));
+
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("MVEL: new com.myhandlers.MyHandler()"));
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("REFLECTION: new com.myhandlers.MyHandler()"));
+
+
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("  MveL:     new com.myhandlers.MyHandler()"));
+        assertEquals("new com.myhandlers.MyHandler()", ddConfigUpdater.parseWorkitemValue("   ReFlEcTIoN:new com.myhandlers.MyHandler()   "));
+
+    }
+
+    @Test
+    public void testGetWorkitemResolver() {
+        assertEquals("mvel", ddConfigUpdater.getWorkitemResolver("new com.myhandlers.MyHandler()", "mvel"));
+        assertEquals("mvel", ddConfigUpdater.getWorkitemResolver("mvel:new com.myhandlers.MyHandler()", "reflection"));
+        assertEquals("reflection", ddConfigUpdater.getWorkitemResolver("reflection:new com.myhandlers.MyHandler()", "mvel"));
+        assertEquals("reflection", ddConfigUpdater.getWorkitemResolver("reflection:new com.myhandlers.MyHandler()", ""));
+    }
+
+}

--- a/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/jbpm-console-ng-workbench-integration/jbpm-console-ng-workbench-integration-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider


### PR DESCRIPTION
Note - DEPENDS ON DESIGNER PR 
https://github.com/droolsjbpm/jbpm-designer/pull/377
(please have jenkins retest this pr once the depends one has been added)

Allow to install workitem information into the deployment descriptor. This is needed for the automatic installation of workitems into the DD for BPMSPL-295.