### PR TITLE
RHBPMS-4199, JBPM-5301 - Different behavior of task service on EAP6 a…

### DIFF
--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/listener/TaskCleanUpProcessEventListenerProducer.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-backend/src/main/java/org/jbpm/console/ng/ht/backend/server/listener/TaskCleanUpProcessEventListenerProducer.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
+
+import org.kie.api.event.process.ProcessEventListener;
 import org.kie.internal.runtime.manager.EventListenerProducer;
 import org.jbpm.runtime.manager.api.qualifiers.Process;
 import org.jbpm.services.task.admin.listener.TaskCleanUpProcessEventListener;
@@ -29,14 +31,14 @@ import org.kie.api.task.TaskService;
  * @author salaboy
  */
 @Process
-public class TaskCleanUpProcessEventListenerProducer implements EventListenerProducer<TaskCleanUpProcessEventListener>{
+public class TaskCleanUpProcessEventListenerProducer implements EventListenerProducer<ProcessEventListener>{
 
     @Inject
     private TaskService taskService;
     
     @Override
-    public List<TaskCleanUpProcessEventListener> getEventListeners(String identifier, Map<String, Object> params) {
-        List<TaskCleanUpProcessEventListener> taskCleanupListeners = new ArrayList<TaskCleanUpProcessEventListener>();
+    public List<ProcessEventListener> getEventListeners(String identifier, Map<String, Object> params) {
+        List<ProcessEventListener> taskCleanupListeners = new ArrayList<ProcessEventListener>();
         taskCleanupListeners.add(new TaskCleanUpProcessEventListener(taskService));
         return taskCleanupListeners;
     }


### PR DESCRIPTION
…nd EAP7

unfortunately couldn't figure out how to write a test for this as the only change is to use the main interface of the listener this producer will return rather than actual impl as it seems CDI impl in wildfly 10 interprets it differently.