### PR TITLE
JBPM-4650 - New case list view

### DIFF
--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/integration/KieServerIntegration.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/integration/KieServerIntegration.java
@@ -258,6 +258,7 @@ public class KieServerIntegration {
             if (serverTemplate.getCapabilities().contains(Capability.PROCESS.name())) {
                 mappedCapabilities.add(KieServerConstants.CAPABILITY_BPM);
                 mappedCapabilities.add(KieServerConstants.CAPABILITY_BPM_UI);
+                mappedCapabilities.add(KieServerConstants.CAPABILITY_CASE);
             }
             if (serverTemplate.getCapabilities().contains(Capability.RULE.name())) {
                 mappedCapabilities.add(KieServerConstants.CAPABILITY_BRM);

--- a/jbpm-console-ng-case-mgmt/.gitignore
+++ b/jbpm-console-ng-case-mgmt/.gitignore
@@ -1,0 +1,24 @@
+/target
+/local
+/src/main/gwt-unitCache/
+/src/main/webapp/WEB-INF/classes/
+/src/main/webapp/WEB-INF/deploy/
+/src/main/webapp/WEB-INF/lib/
+/src/main/webapp/org.drools.guvnor.jBPMShowcase/
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+
+# GwtTest
+gwt-unitCache
+www-test
+
+# Repository wide ignore mac DS_Store files
+.DS_Store
+

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/.gitignore
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/.gitignore
@@ -1,0 +1,19 @@
+/target
+/local
+/src/main/gwt-unitCache/
+/src/main/webapp/WEB-INF/classes/
+/src/main/webapp/WEB-INF/deploy/
+/src/main/webapp/WEB-INF/lib/
+/src/main/webapp/org.drools.guvnor.jBPMShowcase/
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/pom.xml
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-console-ng-case-mgmt</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jbpm-console-ng-case-mgmt-api</artifactId>
+  <packaging>jar</packaging>
+
+  <name>jBPM Console NG - Case Management API</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-generic-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/CaseDefinitionSummary.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/CaseDefinitionSummary.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jbpm.console.ng.ga.model.GenericSummary;
+
+@Portable
+public class CaseDefinitionSummary extends GenericSummary {
+
+    private String containerId;
+
+    public CaseDefinitionSummary() {
+    }
+
+    public CaseDefinitionSummary(final Object id, final String name, final String containerId) {
+        super(id, name);
+        this.containerId = containerId;
+    }
+
+    public String getCaseDefinitionId() {
+        return (String) getId();
+    }
+
+    public void setCaseDefinitionId(String caseDefinitionId) {
+        setId(caseDefinitionId);
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    @Override
+    public String toString() {
+        return "CaseDefinitionSummary{" +
+                "containerId='" + containerId + '\'' +
+                "} " + super.toString();
+    }
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/CaseInstanceSummary.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/CaseInstanceSummary.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jbpm.console.ng.ga.model.GenericSummary;
+
+@Portable
+public class CaseInstanceSummary extends GenericSummary {
+
+    private String description;
+    private Integer status;
+    private String containerId;
+
+    public CaseInstanceSummary() {
+    }
+
+    public CaseInstanceSummary(final String caseId, final String description, final Integer status, final String containerId) {
+        super(caseId, null);
+        this.description = description;
+        this.status = status;
+        this.containerId = containerId;
+    }
+
+    public String getCaseId() {
+        return (String) getId();
+    }
+
+    public void setCaseId(String caseId) {
+        setId(caseId);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    public Boolean isActive() {
+        return status == 1;
+    }
+
+    @Override
+    public String toString() {
+        return "CaseInstanceSummary{" +
+                "description='" + description + '\'' +
+                ", status='" + status + '\'' +
+                ", containerId='" + containerId + '\'' +
+                "} " + super.toString();
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/AbstractCaseEvent.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/AbstractCaseEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.model.events;
+
+public abstract class AbstractCaseEvent {
+
+    private String caseId;
+
+    public AbstractCaseEvent(String caseId) {
+        this.caseId = caseId;
+    }
+
+    public AbstractCaseEvent() {
+    }
+
+    public String getCaseId() {
+        return caseId;
+    }
+
+    public void setCaseId(String caseId) {
+        this.caseId = caseId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractCaseEvent that = (AbstractCaseEvent) o;
+
+        return caseId != null ? caseId.equals(that.caseId) : that.caseId == null;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AvoidMultipleUnaryOperators")
+    public int hashCode() {
+        int result = caseId != null ? caseId.hashCode() : 0;
+        result = ~~result;
+        return result;
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/CaseCancelEvent.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/CaseCancelEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.model.events;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class CaseCancelEvent extends AbstractCaseEvent {
+
+    public CaseCancelEvent(final String caseId) {
+        super(caseId);
+    }
+
+    public CaseCancelEvent() {
+    }
+
+    @Override
+    public String toString() {
+        return "CaseCancelEvent{" + "caseId=" + getCaseId() + '}';
+    }
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/CaseCreatedEvent.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/CaseCreatedEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.model.events;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class CaseCreatedEvent extends AbstractCaseEvent {
+
+    public CaseCreatedEvent() {
+    }
+
+    public CaseCreatedEvent(final String caseId) {
+        super(caseId);
+    }
+
+    @Override
+    public String toString() {
+        return "CaseCreatedEvent{" + "caseId=" + getCaseId() + '}';
+    }
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/CaseDestroyEvent.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/model/events/CaseDestroyEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.model.events;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class CaseDestroyEvent extends AbstractCaseEvent {
+
+    public CaseDestroyEvent() {
+    }
+
+    public CaseDestroyEvent(final String caseId) {
+        super(caseId);
+    }
+
+    @Override
+    public String toString() {
+        return "CaseDestroyEvent{" + "caseId=" + getCaseId() + '}';
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/service/CaseManagementService.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/java/org/jbpm/console/ng/cm/service/CaseManagementService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.service;
+
+import java.util.List;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.jbpm.console.ng.cm.model.CaseDefinitionSummary;
+import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
+
+@Remote
+public interface CaseManagementService {
+
+    List<CaseDefinitionSummary> getCaseDefinitions(String serverTemplateId, Integer page, Integer pageSize);
+
+    String startCaseInstance(String serverTemplateId, String containerId, String caseDefinitionId);
+
+    List<CaseInstanceSummary> getCaseInstances(String serverTemplateId, Integer page, Integer pageSize);
+
+    void cancelCaseInstance(String serverTemplateId, String containerId, String caseId);
+
+    void destroyCaseInstance(String serverTemplateId, String containerId, String caseId);
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/resources/ErraiApp.properties
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/resources/org/jbpm/console/ng/cm/JbpmConsoleNGCaseMgmtAPI.gwt.xml
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-api/src/main/resources/org/jbpm/console/ng/cm/JbpmConsoleNGCaseMgmtAPI.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+  <inherits name='org.jboss.errai.bus.ErraiBus'/>
+
+  <source path="model"/>
+  <source path="service"/>
+
+</module>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/.gitignore
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/.gitignore
@@ -1,0 +1,19 @@
+/target
+/local
+/src/main/gwt-unitCache/
+/src/main/webapp/WEB-INF/classes/
+/src/main/webapp/WEB-INF/deploy/
+/src/main/webapp/WEB-INF/lib/
+/src/main/webapp/org.drools.guvnor.jBPMShowcase/
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/pom.xml
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-console-ng-case-mgmt</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jbpm-console-ng-case-mgmt-backend</artifactId>
+  <packaging>jar</packaging>
+
+  <name>jBPM Console NG - Case Management Backend</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-generic-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-case-mgmt-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-business-domain-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/main/java/org/jbpm/console/ng/cm/backend/server/RemoteCaseManagementServiceImpl.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/main/java/org/jbpm/console/ng/cm/backend/server/RemoteCaseManagementServiceImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.backend.server;
+
+import java.util.List;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.jbpm.console.ng.bd.integration.AbstractKieServerService;
+import org.jbpm.console.ng.cm.model.CaseDefinitionSummary;
+import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
+import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.kie.server.api.model.cases.CaseDefinition;
+import org.kie.server.api.model.cases.CaseInstance;
+import org.kie.server.client.CaseServicesClient;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.*;
+
+@Service
+@ApplicationScoped
+public class RemoteCaseManagementServiceImpl extends AbstractKieServerService implements CaseManagementService {
+
+    @Override
+    public List<CaseDefinitionSummary> getCaseDefinitions(final String serverTemplateId, final Integer page, final Integer pageSize) {
+        if (serverTemplateId == null || serverTemplateId.isEmpty()) {
+            return emptyList();
+        }
+
+        final CaseServicesClient client = getClient(serverTemplateId, CaseServicesClient.class);
+
+        final List<CaseDefinition> caseDefinitions = client.getCaseDefinitions(page, pageSize);
+
+        return caseDefinitions.stream()
+                .map(cd -> new CaseDefinitionSummary(cd.getIdentifier(), cd.getName(), cd.getContainerId()))
+                .collect(toList());
+    }
+
+    @Override
+    public List<CaseInstanceSummary> getCaseInstances(final String serverTemplateId, final Integer page, final Integer pageSize) {
+        if (serverTemplateId == null || serverTemplateId.isEmpty()) {
+            return emptyList();
+        }
+
+        final CaseServicesClient client = getClient(serverTemplateId, CaseServicesClient.class);
+
+        final List<CaseInstance> caseInstances = client.getCaseInstances(page, pageSize);
+
+        return caseInstances.stream()
+                .map(ci -> new CaseInstanceSummary(ci.getCaseId(), ci.getCaseDescription(), ci.getCaseStatus(), ci.getContainerId()))
+                .collect(toList());
+    }
+
+    @Override
+    public String startCaseInstance(final String serverTemplateId, final String containerId, final String caseDefinitionId) {
+        if (serverTemplateId == null || serverTemplateId.isEmpty()) {
+            return null;
+        }
+
+        final CaseServicesClient client = getClient(serverTemplateId, containerId, CaseServicesClient.class);
+
+        return client.startCase(containerId, caseDefinitionId);
+    }
+
+    @Override
+    public void cancelCaseInstance(final String serverTemplateId, final String containerId, final String caseId) {
+        if (serverTemplateId == null || serverTemplateId.isEmpty()) {
+            return;
+        }
+
+        final CaseServicesClient client = getClient(serverTemplateId, containerId, CaseServicesClient.class);
+
+        client.cancelCaseInstance(containerId, caseId);
+    }
+
+    @Override
+    public void destroyCaseInstance(final String serverTemplateId, final String containerId, final String caseId) {
+        if (serverTemplateId == null || serverTemplateId.isEmpty()) {
+            return;
+        }
+
+        final CaseServicesClient client = getClient(serverTemplateId, containerId, CaseServicesClient.class);
+
+        client.destroyCaseInstance(containerId, caseId);
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/main/resources/ErraiApp.properties
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/main/resources/META-INF/beans.xml
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/test/java/org/jbpm/console/ng/cm/backend/server/RemoteCaseManagementServiceImplTest.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-backend/src/test/java/org/jbpm/console/ng/cm/backend/server/RemoteCaseManagementServiceImplTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.backend.server;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jbpm.console.ng.bd.integration.KieServerIntegration;
+import org.jbpm.console.ng.cm.model.CaseDefinitionSummary;
+import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
+import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.cases.CaseDefinition;
+import org.kie.server.api.model.cases.CaseInstance;
+import org.kie.server.client.CaseServicesClient;
+import org.kie.server.client.KieServicesClient;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.lang.String.format;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteCaseManagementServiceImplTest {
+
+    @Mock
+    KieServicesClient kieServicesClient;
+
+    @Mock
+    CaseServicesClient caseServicesClient;
+
+    @Mock
+    KieServerIntegration kieServerIntegration;
+
+    @InjectMocks
+    RemoteCaseManagementServiceImpl service;
+
+    @Before
+    public void setup() {
+        when(kieServerIntegration.getServerClient(anyString())).thenReturn(kieServicesClient);
+        when(kieServerIntegration.getServerClient(anyString(), anyString())).thenReturn(kieServicesClient);
+        when(kieServicesClient.getServicesClient(CaseServicesClient.class)).thenReturn(caseServicesClient);
+    }
+
+    @Test
+    public void testInvalidServerTemplate() throws Exception {
+        final Method[] methods = CaseManagementService.class.getMethods();
+        for (Method method : methods) {
+            final Class<?> returnType = method.getReturnType();
+            final Object[] args = new Object[method.getParameterCount()];
+            Object result = method.invoke(service, args);
+
+            assertMethodResult(method, returnType, result);
+
+            args[0] = "";
+            result = method.invoke(service, args);
+            assertMethodResult(method, returnType, result);
+        }
+    }
+
+    private void assertMethodResult(final Method method, final Class<?> returnType, final Object result) {
+        if (Collection.class.isAssignableFrom(returnType)) {
+            assertNotNull(format("Returned collection for method %s should not be null", method.getName()), result);
+            assertTrue(format("Returned collection for method %s should be empty", method.getName()), ((Collection) result).isEmpty());
+        } else {
+            assertNull(format("Returned object for method %s should be null", method.getName()), result);
+        }
+    }
+
+    @Test
+    public void testGetCaseDefinitions() throws Exception {
+        final CaseDefinition definition = new CaseDefinition();
+        definition.setIdentifier("org.jbpm.case");
+        definition.setName("New case");
+        definition.setContainerId("org.jbpm");
+        when(caseServicesClient.getCaseDefinitions(anyInt(), anyInt())).thenReturn(Collections.singletonList(definition));
+
+        final List<CaseDefinitionSummary> definitions = service.getCaseDefinitions("id", 0, 0);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        final CaseDefinitionSummary caseDefinitionSummary = definitions.get(0);
+        assertEquals(definition.getName(), caseDefinitionSummary.getName());
+        assertEquals(definition.getIdentifier(), caseDefinitionSummary.getId());
+        assertEquals(definition.getContainerId(), caseDefinitionSummary.getContainerId());
+    }
+
+    @Test
+    public void testGetCaseInstances() throws Exception {
+        final CaseInstance instance = new CaseInstance();
+        instance.setCaseDescription("New case");
+        instance.setCaseId("CASE-1");
+        instance.setCaseStatus(1);
+        instance.setContainerId("org.jbpm");
+        when(caseServicesClient.getCaseInstances(anyInt(), anyInt())).thenReturn(Collections.singletonList(instance));
+
+        final List<CaseInstanceSummary> instances = service.getCaseInstances("id", 0, 0);
+        assertNotNull(instances);
+        assertEquals(1, instances.size());
+        final CaseInstanceSummary caseInstanceSummary = instances.get(0);
+        assertEquals(instance.getCaseDescription(), caseInstanceSummary.getDescription());
+        assertEquals(instance.getCaseId(), caseInstanceSummary.getId());
+        assertEquals(instance.getCaseStatus(), caseInstanceSummary.getStatus());
+        assertEquals(instance.getContainerId(), caseInstanceSummary.getContainerId());
+        assertTrue(caseInstanceSummary.isActive());
+    }
+
+    @Test
+    public void testStartCaseInstance() throws Exception {
+        final String caseDefinitionId = "org.jbpm";
+        final String container = "container";
+
+        service.startCaseInstance("server", container, caseDefinitionId);
+
+        verify(caseServicesClient).startCase(container, caseDefinitionId);
+    }
+
+    @Test
+    public void testCancelCaseInstance() throws Exception {
+        final String caseId = "CASE-1";
+        final String container = "container";
+
+        service.cancelCaseInstance("server", container, caseId);
+
+        verify(caseServicesClient).cancelCaseInstance(container, caseId);
+    }
+
+    @Test
+    public void testDestroyCaseInstance() throws Exception {
+        final String caseId = "CASE-1";
+        final String container = "container";
+
+        service.destroyCaseInstance("server", container, caseId);
+
+        verify(caseServicesClient).destroyCaseInstance(container, caseId);
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/.gitignore
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/.gitignore
@@ -1,0 +1,19 @@
+/target
+/local
+/src/main/gwt-unitCache/
+/src/main/webapp/WEB-INF/classes/
+/src/main/webapp/WEB-INF/deploy/
+/src/main/webapp/WEB-INF/lib/
+/src/main/webapp/org.drools.guvnor.jBPMShowcase/
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/pom.xml
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-console-ng-case-mgmt</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jbpm-console-ng-case-mgmt-client</artifactId>
+  <packaging>jar</packaging>
+
+  <name>jBPM Console NG - Case Management Client</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3-extras</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-case-mgmt-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-generic-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-console-ng-generic-api</artifactId>
+    </dependency>
+
+    <!-- Uberfire -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-table</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-service-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.widgets</groupId>
+      <artifactId>kie-wb-common-ui</artifactId>
+    </dependency>
+
+    <!-- Errai -->
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <!-- GWT and GWT Extensions -->
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/list/CaseInstanceListPresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/list/CaseInstanceListPresenter.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.list;
+
+import java.util.List;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import com.google.gwt.view.client.Range;
+import org.jboss.errai.common.client.api.Caller;
+import org.jbpm.console.ng.cm.client.newcase.NewCaseInstancePresenter;
+import org.jbpm.console.ng.cm.client.resources.i18n.Constants;
+import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
+import org.jbpm.console.ng.cm.model.events.CaseCancelEvent;
+import org.jbpm.console.ng.cm.model.events.CaseCreatedEvent;
+import org.jbpm.console.ng.cm.model.events.CaseDestroyEvent;
+import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.jbpm.console.ng.ga.model.PortableQueryFilter;
+import org.jbpm.console.ng.gc.client.list.base.AbstractListView.ListView;
+import org.jbpm.console.ng.gc.client.list.base.AbstractScreenListPresenter;
+import org.uberfire.client.annotations.WorkbenchMenu;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.client.mvp.UberView;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
+import org.uberfire.ext.widgets.common.client.menu.RefreshMenuBuilder;
+import org.uberfire.ext.widgets.common.client.menu.RefreshSelectorMenuBuilder;
+import org.uberfire.paging.PageResponse;
+import org.uberfire.workbench.model.menu.MenuFactory;
+import org.uberfire.workbench.model.menu.Menus;
+
+@Dependent
+@WorkbenchScreen(identifier = CaseInstanceListPresenter.SCREEN_ID)
+public class CaseInstanceListPresenter extends AbstractScreenListPresenter<CaseInstanceSummary> {
+
+    public static final String SCREEN_ID = "Case List";
+
+    private Constants constants = Constants.INSTANCE;
+
+    @Inject
+    private CaseInstanceListView view;
+
+    private Caller<CaseManagementService> casesService;
+
+    private Event<CaseCancelEvent> caseCancelEvent;
+
+    private Event<CaseDestroyEvent> caseDestroyEvent;
+
+    @Inject
+    private NewCaseInstancePresenter newCaseInstancePresenter;
+
+    @Override
+    protected ListView getListView() {
+        return view;
+    }
+
+    @Override
+    public void getData(final Range visibleRange) {
+        if (currentFilter == null) {
+            currentFilter = new PortableQueryFilter(
+                    visibleRange.getStart(),
+                    visibleRange.getLength(),
+                    false,
+                    "",
+                    "",
+                    false
+            );
+        }
+
+        currentFilter.setOffset(visibleRange.getStart());
+        currentFilter.setCount(visibleRange.getLength());
+
+        casesService.call((List<CaseInstanceSummary> cases) -> {
+            final PageResponse<CaseInstanceSummary> response = new PageResponse<CaseInstanceSummary>();
+            response.setStartRowIndex(currentFilter.getOffset());
+            response.setTotalRowSize(cases.size());
+            response.setPageRowList(cases);
+            response.setTotalRowSizeExact(cases.isEmpty());
+            if (cases.size() < visibleRange.getLength()) {
+                response.setLastPage(true);
+            } else {
+                response.setLastPage(false);
+            }
+            updateDataOnCallback(response);
+        }, new DefaultErrorCallback()).getCaseInstances(
+                selectedServerTemplate,
+                currentFilter.getOffset() / currentFilter.getCount(),
+                currentFilter.getCount()
+        );
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return constants.CasesList();
+    }
+
+    @WorkbenchPartView
+    public UberView<CaseInstanceListPresenter> getView() {
+        return view;
+    }
+
+    @WorkbenchMenu
+    public Menus buildMenu() {
+        return MenuFactory
+                .newTopLevelMenu(constants.NewCaseInstance())
+                .respondsWith(() -> {
+                    if (selectedServerTemplate != null && !selectedServerTemplate.isEmpty()) {
+                        newCaseInstancePresenter.show(selectedServerTemplate);
+                    } else {
+                        view.displayNotification(constants.SelectServerTemplate());
+                    }
+                })
+                .endMenu()
+                .newTopLevelCustomMenu(serverTemplateSelectorMenuBuilder)
+                .endMenu()
+                .newTopLevelCustomMenu(new RefreshMenuBuilder(this))
+                .endMenu()
+                .newTopLevelCustomMenu(new RefreshSelectorMenuBuilder(this))
+                .endMenu()
+                .build();
+    }
+
+    protected void cancelCaseInstance(final CaseInstanceSummary caseInstanceSummary) {
+        casesService.call(
+                e -> caseCancelEvent.fire(new CaseCancelEvent(caseInstanceSummary.getCaseId())),
+                new DefaultErrorCallback()
+        ).cancelCaseInstance(selectedServerTemplate, caseInstanceSummary.getContainerId(), caseInstanceSummary.getCaseId());
+    }
+
+    protected void destroyCaseInstance(final CaseInstanceSummary caseInstanceSummary) {
+        casesService.call(
+                e -> caseDestroyEvent.fire(new CaseDestroyEvent(caseInstanceSummary.getCaseId())),
+                new DefaultErrorCallback()
+        ).destroyCaseInstance(selectedServerTemplate, caseInstanceSummary.getContainerId(), caseInstanceSummary.getCaseId());
+    }
+
+    public void onCaseCreatedEvent(@Observes CaseCreatedEvent event) {
+        refreshGrid();
+    }
+
+    public void onCaseDestroyEvent(@Observes CaseDestroyEvent event) {
+        refreshGrid();
+    }
+
+    public void onCaseCancelEvent(@Observes CaseCancelEvent event) {
+        refreshGrid();
+    }
+
+    @Inject
+    public void setCasesService(final Caller<CaseManagementService> casesService) {
+        this.casesService = casesService;
+    }
+
+    @Inject
+    public void setCaseCancelEvent(final Event<CaseCancelEvent> caseCancelEvent) {
+        this.caseCancelEvent = caseCancelEvent;
+    }
+
+    @Inject
+    public void setCaseDestroyEvent(final Event<CaseDestroyEvent> caseDestroyEvent) {
+        this.caseDestroyEvent = caseDestroyEvent;
+    }
+
+    public interface CaseInstanceListView extends ListView<CaseInstanceSummary, CaseInstanceListPresenter> {
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/list/CaseInstanceListViewImpl.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/list/CaseInstanceListViewImpl.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.list;
+
+import java.util.LinkedList;
+import java.util.List;
+import javax.enterprise.context.Dependent;
+
+import com.google.gwt.cell.client.ActionCell;
+import com.google.gwt.cell.client.Cell;
+import com.google.gwt.cell.client.CompositeCell;
+import com.google.gwt.cell.client.HasCell;
+import com.google.gwt.cell.client.TextCell;
+import com.google.gwt.dom.client.BrowserEvents;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.cellview.client.Column;
+import com.google.gwt.view.client.CellPreviewEvent;
+import com.google.gwt.view.client.DefaultSelectionEventManager;
+import com.google.gwt.view.client.NoSelectionModel;
+import org.jbpm.console.ng.cm.client.resources.i18n.Constants;
+import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
+import org.jbpm.console.ng.gc.client.experimental.grid.base.ExtendedPagedTable;
+import org.jbpm.console.ng.gc.client.list.base.AbstractListView;
+import org.jbpm.console.ng.gc.client.util.ButtonActionCell;
+import org.uberfire.ext.services.shared.preferences.GridGlobalPreferences;
+import org.uberfire.ext.widgets.table.client.ColumnMeta;
+
+import static java.util.Arrays.*;
+
+@Dependent
+public class CaseInstanceListViewImpl extends AbstractListView<CaseInstanceSummary, CaseInstanceListPresenter>
+        implements CaseInstanceListPresenter.CaseInstanceListView {
+
+    public static final String COL_ID_CASE_ID = "caseId";
+    public static final String COL_ID_DESCRIPTION = "description";
+    public static final String COL_ID_STATUS = "status";
+    public static final String COL_ID_ACTIONS = "Actions";
+    public static final String CASE_INSTANCE_LIST_GRID = "CaseInstanceListGrid";
+
+    private final Constants constants = Constants.INSTANCE;
+
+    @Override
+    public void init(final CaseInstanceListPresenter presenter) {
+        final List<String> bannedColumns = asList(COL_ID_CASE_ID, COL_ID_ACTIONS);
+        final List<String> initColumns = asList(COL_ID_CASE_ID, COL_ID_DESCRIPTION, COL_ID_STATUS, COL_ID_ACTIONS);
+        super.init(presenter, new GridGlobalPreferences(CASE_INSTANCE_LIST_GRID, initColumns, bannedColumns));
+
+        selectionModel = new NoSelectionModel<>();
+        selectionModel.addSelectionChangeHandler(e -> {
+            if (selectedRow == -1) {
+                selectedRow = listGrid.getKeyboardSelectedRow();
+                listGrid.setRowStyles(selectedStyles);
+                listGrid.redraw();
+            } else if (listGrid.getKeyboardSelectedRow() != selectedRow) {
+                listGrid.setRowStyles(selectedStyles);
+                selectedRow = listGrid.getKeyboardSelectedRow();
+                listGrid.redraw();
+            }
+
+            selectedItem = selectionModel.getLastSelectedObject();
+        });
+
+        noActionColumnManager = DefaultSelectionEventManager
+                .createCustomManager(new DefaultSelectionEventManager.EventTranslator<CaseInstanceSummary>() {
+
+                    @Override
+                    public boolean clearCurrentSelection(CellPreviewEvent<CaseInstanceSummary> event) {
+                        return false;
+                    }
+
+                    @Override
+                    public DefaultSelectionEventManager.SelectAction translateSelectionEvent(CellPreviewEvent<CaseInstanceSummary> event) {
+                        NativeEvent nativeEvent = event.getNativeEvent();
+                        if (BrowserEvents.CLICK.equals(nativeEvent.getType()) &&
+                                // Ignore if the event didn't occur in the correct column.
+                                listGrid.getColumnIndex(actionsColumn) == event.getColumn()) {
+                            return DefaultSelectionEventManager.SelectAction.IGNORE;
+                        }
+                        return DefaultSelectionEventManager.SelectAction.DEFAULT;
+                    }
+                });
+        listGrid.setSelectionModel(selectionModel, noActionColumnManager);
+        listGrid.setEmptyTableCaption(constants.NoCasesFound());
+        listGrid.setRowStyles(selectedStyles);
+
+        listGrid.getElement().getStyle().setPaddingRight(20, Style.Unit.PX);
+        listGrid.getElement().getStyle().setPaddingLeft(20, Style.Unit.PX);
+    }
+
+    @Override
+    public void initColumns(final ExtendedPagedTable<CaseInstanceSummary> table) {
+        initCellPreview();
+        final Column idColumn = initIdColumn();
+        final Column descriptionColumn = initDescriptionColumn();
+        final Column statusColumn = initStatusColumn();
+        actionsColumn = initActionsColumn();
+
+        table.addColumns(asList(
+                new ColumnMeta<>(idColumn, constants.Id()),
+                new ColumnMeta<>(descriptionColumn, constants.Description()),
+                new ColumnMeta<>(statusColumn, constants.Status()),
+                new ColumnMeta<>(actionsColumn, constants.Actions())
+        ));
+    }
+
+    private void initCellPreview() {
+        listGrid.addCellPreviewHandler(event -> {
+            if (BrowserEvents.MOUSEOVER.equalsIgnoreCase(event.getNativeEvent().getType())) {
+                onMouseOverGrid(event);
+            }
+        });
+    }
+
+    private void onMouseOverGrid(final CellPreviewEvent<CaseInstanceSummary> event) {
+        final CaseInstanceSummary caseInstance = event.getValue();
+        if (caseInstance.getDescription() != null) {
+            listGrid.setTooltip(listGrid.getKeyboardSelectedRow(), event.getColumn(), caseInstance.getDescription());
+        }
+    }
+
+    private Column initIdColumn() {
+        final Column<CaseInstanceSummary, String> caseIdColumn = new Column<CaseInstanceSummary, String>(new TextCell()) {
+            @Override
+            public String getValue(final CaseInstanceSummary caseInstanceSummary) {
+                return caseInstanceSummary.getCaseId();
+            }
+        };
+        caseIdColumn.setSortable(true);
+        caseIdColumn.setDataStoreName(COL_ID_CASE_ID);
+        return caseIdColumn;
+    }
+
+    private Column initDescriptionColumn() {
+        final Column<CaseInstanceSummary, String> descriptionColumn = new Column<CaseInstanceSummary, String>(new TextCell()) {
+            @Override
+            public String getValue(final CaseInstanceSummary caseInstanceSummary) {
+                return caseInstanceSummary.getDescription();
+            }
+        };
+        descriptionColumn.setSortable(true);
+        descriptionColumn.setDataStoreName(COL_ID_DESCRIPTION);
+        return descriptionColumn;
+    }
+
+    private Column initStatusColumn() {
+        final Column<CaseInstanceSummary, String> statusColumn = new Column<CaseInstanceSummary, String>(new TextCell()) {
+            @Override
+            public String getValue(final CaseInstanceSummary caseInstanceSummary) {
+                if (caseInstanceSummary.isActive()) {
+                    return constants.Active();
+                } else {
+                    return "";
+                }
+            }
+        };
+        statusColumn.setSortable(true);
+        statusColumn.setDataStoreName(COL_ID_STATUS);
+        return statusColumn;
+    }
+
+    private Column initActionsColumn() {
+        final List<HasCell<CaseInstanceSummary, ?>> cells = new LinkedList<>();
+
+        cells.add(new CancelActionHasCell(constants.Complete(), (CaseInstanceSummary caseInstanceSummary) ->
+                presenter.cancelCaseInstance(caseInstanceSummary)
+        ));
+
+        cells.add(new DestroyActionHasCell(constants.Close(), (CaseInstanceSummary caseInstanceSummary) ->
+                presenter.destroyCaseInstance(caseInstanceSummary)
+        ));
+
+        final CompositeCell<CaseInstanceSummary> cell = new CompositeCell<>(cells);
+        final Column<CaseInstanceSummary, CaseInstanceSummary> actionsColumn = new Column<CaseInstanceSummary, CaseInstanceSummary>(cell) {
+            @Override
+            public CaseInstanceSummary getValue(final CaseInstanceSummary caseInstanceSummary) {
+                return caseInstanceSummary;
+            }
+        };
+
+        actionsColumn.setDataStoreName(COL_ID_ACTIONS);
+        return actionsColumn;
+    }
+
+    protected class CancelActionHasCell extends ButtonActionCell<CaseInstanceSummary> {
+
+        public CancelActionHasCell(final String text, final ActionCell.Delegate<CaseInstanceSummary> delegate) {
+            super(text, delegate);
+        }
+
+        @Override
+        public void render(final Cell.Context context, final CaseInstanceSummary caseInstanceSummary, final SafeHtmlBuilder sb) {
+            if (caseInstanceSummary.isActive()) {
+                super.render(context, caseInstanceSummary, sb);
+            }
+        }
+    }
+
+    protected class DestroyActionHasCell extends ButtonActionCell<CaseInstanceSummary> {
+
+        public DestroyActionHasCell(final String text, final ActionCell.Delegate<CaseInstanceSummary> delegate) {
+            super(text, delegate);
+        }
+
+        @Override
+        public void render(final Cell.Context context, final CaseInstanceSummary caseInstanceSummary, final SafeHtmlBuilder sb) {
+            if (caseInstanceSummary.isActive()) {
+                super.render(context, caseInstanceSummary, sb);
+            }
+        }
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstancePresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstancePresenter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.newcase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.Caller;
+import org.jbpm.console.ng.cm.client.resources.i18n.Constants;
+import org.jbpm.console.ng.cm.model.CaseDefinitionSummary;
+import org.jbpm.console.ng.cm.model.events.CaseCreatedEvent;
+import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.uberfire.client.mvp.UberView;
+import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
+import org.uberfire.workbench.events.NotificationEvent;
+
+@Dependent
+public class NewCaseInstancePresenter {
+
+    private final Map<String, CaseDefinitionSummary> caseDefinitions = new HashMap<>();
+
+    @Inject
+    private NewCaseInstanceView view;
+
+    private Caller<CaseManagementService> caseService;
+
+    private Event<NotificationEvent> notification;
+
+    private Event<CaseCreatedEvent> newCaseEvent;
+
+    private String serverTemplateId;
+
+    @PostConstruct
+    public void init() {
+        view.init(this);
+    }
+
+    public void show(final String serverTemplateId) {
+        this.serverTemplateId = serverTemplateId;
+        loadCaseDefinitions();
+    }
+
+    protected void loadCaseDefinitions() {
+        view.clearCaseDefinitions();
+        caseDefinitions.clear();
+        caseService.call(
+                (List<CaseDefinitionSummary> definitions) -> {
+                    final List<String> definitionNames = new ArrayList<>();
+                    for (CaseDefinitionSummary summary : definitions) {
+                        definitionNames.add(summary.getName());
+                        caseDefinitions.put(summary.getName(), summary);
+                    }
+                    Collections.sort(definitionNames);
+                    view.addCaseDefinitions(definitionNames);
+                    view.show();
+                },
+                new DefaultErrorCallback()
+        ).getCaseDefinitions(serverTemplateId, 0, Integer.MAX_VALUE);
+    }
+
+    protected void createCaseInstance(final String caseDefinitionName) {
+        final CaseDefinitionSummary caseDefinition = caseDefinitions.get(caseDefinitionName);
+        if (caseDefinition == null) {
+            notification.fire(new NotificationEvent(Constants.INSTANCE.InvalidCaseDefinition(), NotificationEvent.NotificationType.ERROR));
+            return;
+        }
+        caseService.call(
+                (String caseId) -> {
+                    view.hide();
+                    notification.fire(new NotificationEvent(Constants.INSTANCE.CaseCreatedWithId(caseId), NotificationEvent.NotificationType.SUCCESS));
+                    newCaseEvent.fire(new CaseCreatedEvent(caseId));
+                },
+                new DefaultErrorCallback()
+        ).startCaseInstance(serverTemplateId, caseDefinition.getContainerId(), caseDefinition.getCaseDefinitionId());
+    }
+
+    @Inject
+    public void setNotification(final Event<NotificationEvent> notification) {
+        this.notification = notification;
+    }
+
+    @Inject
+    public void setNewCaseEvent(final Event<CaseCreatedEvent> newCaseEvent) {
+        this.newCaseEvent = newCaseEvent;
+    }
+
+    @Inject
+    public void setCaseService(final Caller<CaseManagementService> caseService) {
+        this.caseService = caseService;
+    }
+
+    public interface NewCaseInstanceView extends UberView<NewCaseInstancePresenter> {
+
+        void show();
+
+        void hide();
+
+        void clearCaseDefinitions();
+
+        void addCaseDefinitions(List<String> definitions);
+
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstanceViewImpl.html
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstanceViewImpl.html
@@ -1,0 +1,11 @@
+<form class="horizontal">
+    <fieldset>
+        <div class="form-group" data-field="definition-name-group">
+            <label class="control-label col-md-3" data-field="definition-name-label"></label>
+            <div class="col-md-9">
+                <select data-field="definition-name-select"></select>
+                <span data-field="definition-name-help" class="help-block"></span>
+            </div>
+        </div>
+    </fieldset>
+</form>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstanceViewImpl.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstanceViewImpl.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.newcase;
+
+import java.util.List;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.Composite;
+import org.gwtbootstrap3.client.ui.FormLabel;
+import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+import org.gwtbootstrap3.extras.select.client.ui.Option;
+import org.gwtbootstrap3.extras.select.client.ui.Select;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.jbpm.console.ng.cm.client.resources.i18n.Constants;
+import org.uberfire.ext.widgets.common.client.common.StyleHelper;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+import org.uberfire.ext.widgets.common.client.common.popups.footers.GenericModalFooter;
+
+import static com.google.common.base.Strings.*;
+
+@Dependent
+@Templated
+public class NewCaseInstanceViewImpl extends Composite implements NewCaseInstancePresenter.NewCaseInstanceView {
+
+    private final Constants constants = Constants.INSTANCE;
+    private final BaseModal modal = GWT.create(BaseModal.class);
+
+    @DataField("definition-name-group")
+    Element caseDefinitionNameGroup = DOM.createDiv();
+
+    @Inject
+    @DataField("definition-name-help")
+    HelpBlock definitionNameHelp;
+
+    @DataField("definition-name-select")
+    Select caseTemplatesList = GWT.create(Select.class);
+
+    @Inject
+    @DataField("definition-name-label")
+    FormLabel caseDefinitionNameLabel;
+
+    private NewCaseInstancePresenter presenter;
+
+    @Override
+    public void init(final NewCaseInstancePresenter presenter) {
+        this.presenter = presenter;
+
+        this.modal.setTitle(constants.NewCaseInstance());
+        this.modal.setBody(this);
+        final GenericModalFooter footer = GWT.create(GenericModalFooter.class);
+        footer.addButton(
+                Constants.INSTANCE.Create(),
+                () -> okButton(),
+                IconType.PLUS,
+                ButtonType.PRIMARY
+        );
+        this.modal.add(footer);
+
+        caseDefinitionNameLabel.setText(constants.CaseDefinition());
+        caseDefinitionNameLabel.setShowRequiredIndicator(true);
+    }
+
+    public void show() {
+        cleanForm();
+        this.modal.show();
+    }
+
+    private void okButton() {
+        if (validateForm()) {
+            createCaseInstance();
+        }
+    }
+
+    @Override
+    public void clearCaseDefinitions() {
+        caseTemplatesList.clear();
+    }
+
+    @Override
+    public void addCaseDefinitions(final List<String> definitions) {
+        for (final String definition : definitions) {
+            final Option option = GWT.create(Option.class);
+            option.setText(definition);
+            option.setValue(definition);
+            caseTemplatesList.add(option);
+        }
+
+        caseTemplatesList.refresh();
+    }
+
+    public void cleanForm() {
+        caseTemplatesList.setValue("");
+        caseTemplatesList.setFocus(true);
+        clearErrorMessages();
+    }
+
+    @Override
+    public void hide() {
+        cleanForm();
+        this.modal.hide();
+    }
+
+    private boolean validateForm() {
+        clearErrorMessages();
+
+        if (isNullOrEmpty(caseTemplatesList.getValue())) {
+            caseTemplatesList.setFocus(true);
+            definitionNameHelp.setText(constants.PleaseSelectACaseDefinition());
+            setCaseDefinitionNameGroupStyle(ValidationState.ERROR);
+            return false;
+        } else {
+            setCaseDefinitionNameGroupStyle(ValidationState.SUCCESS);
+            return true;
+        }
+    }
+
+    private void setCaseDefinitionNameGroupStyle(final ValidationState error) {
+        StyleHelper.addUniqueEnumStyleName(caseDefinitionNameGroup, ValidationState.class, error);
+    }
+
+    private void createCaseInstance() {
+        presenter.createCaseInstance(caseTemplatesList.getValue());
+    }
+
+    private void clearErrorMessages() {
+        definitionNameHelp.setText("");
+        setCaseDefinitionNameGroupStyle(ValidationState.NONE);
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/perspectives/CaseInstanceListPerspective.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/perspectives/CaseInstanceListPerspective.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.perspectives;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jbpm.console.ng.cm.client.list.CaseInstanceListPresenter;
+import org.jbpm.console.ng.gc.client.perspectives.AbstractPerspective;
+import org.uberfire.client.annotations.Perspective;
+import org.uberfire.client.annotations.WorkbenchPerspective;
+import org.uberfire.client.workbench.panels.impl.SimpleWorkbenchPanelPresenter;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.workbench.model.impl.PartDefinitionImpl;
+import org.uberfire.workbench.model.impl.PerspectiveDefinitionImpl;
+
+@ApplicationScoped
+@WorkbenchPerspective(identifier = CaseInstanceListPerspective.PERSPECTIVE_ID)
+public class CaseInstanceListPerspective extends AbstractPerspective {
+
+    public static final String PERSPECTIVE_ID = "Cases";
+
+    @Perspective
+    public PerspectiveDefinition getPerspective() {
+        final PerspectiveDefinition p = new PerspectiveDefinitionImpl(SimpleWorkbenchPanelPresenter.class.getName());
+        p.setName("Cases");
+        p.getRoot().addPart(new PartDefinitionImpl(new DefaultPlaceRequest(CaseInstanceListPresenter.SCREEN_ID)));
+        return p;
+    }
+
+    @Override
+    public String getPerspectiveId() {
+        return PERSPECTIVE_ID;
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/resources/i18n/Constants.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/resources/i18n/Constants.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.resources.i18n;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.i18n.client.Messages;
+
+public interface Constants extends Messages {
+
+    Constants INSTANCE = GWT.create(Constants.class);
+
+    String Id();
+
+    String Case();
+
+    String Description();
+
+    String Status();
+
+    String Actions();
+
+    String NoCasesFound();
+
+    String CasesList();
+
+    String Create();
+
+    String NewCaseInstance();
+
+    String CaseCreatedWithId(String caseId);
+
+    String Close();
+
+    String SelectServerTemplate();
+
+    String Complete();
+
+    String Active();
+
+    String InvalidCaseDefinition();
+
+    String CaseDefinition();
+
+    String PleaseSelectACaseDefinition();
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/resources/ErraiApp.properties
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/resources/org/jbpm/console/ng/cm/JbpmConsoleNGCaseMgmtClient.gwt.xml
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/resources/org/jbpm/console/ng/cm/JbpmConsoleNGCaseMgmtClient.gwt.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+  <inherits name="com.google.gwt.i18n.I18N"/>
+  <inherits name="com.google.gwt.http.HTTP"/>
+  <inherits name="com.google.gwt.user.User"/>
+  <inherits name="com.google.gwt.resources.Resources"/>
+  <inherits name="org.gwtbootstrap3.extras.select.Select"/>
+
+  <inherits name="org.jboss.errai.ui.UI"/>
+  <inherits name="org.uberfire.UberfireClientAPI"/>
+
+  <inherits name="org.jbpm.console.ng.cm.JbpmConsoleNGCaseMgmtAPI"/>
+
+  <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
+
+</module>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/resources/org/jbpm/console/ng/cm/client/resources/i18n/Constants.properties
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/resources/org/jbpm/console/ng/cm/client/resources/i18n/Constants.properties
@@ -1,0 +1,17 @@
+Actions=Actions
+Active=Active
+Case=Case
+CaseCreatedWithId=Case Created with Id {0}
+CaseDefinition=Case Definition
+CasesList=Cases List
+Close=Close
+Complete=Complete
+Create=Create
+Description=Description
+Id=Id
+InvalidCaseDefinition=Invalid Case Definition
+NewCaseInstance=New Case Instance
+NoCasesFound=No Cases Found
+PleaseSelectACaseDefinition=Please select a Case Definition
+SelectServerTemplate=Select server template
+Status=Status

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/test/java/org/jbpm/console/ng/cm/client/list/CaseInstanceListPresenterTest.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/test/java/org/jbpm/console/ng/cm/client/list/CaseInstanceListPresenterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.list;
+
+import java.util.Arrays;
+
+import com.google.gwt.view.client.Range;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
+import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
+import org.jbpm.console.ng.cm.model.events.CaseCancelEvent;
+import org.jbpm.console.ng.cm.model.events.CaseDestroyEvent;
+import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.jbpm.console.ng.gc.client.experimental.grid.base.ExtendedPagedTable;
+import org.jbpm.console.ng.gc.client.menu.ServerTemplateSelectorMenuBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CaseInstanceListPresenterTest {
+
+    @Mock
+    CaseManagementService caseManagementService;
+
+    Caller<CaseManagementService> casesService;
+
+    @Mock
+    ServerTemplateSelectorMenuBuilder serverTemplateSelectorMenuBuilder;
+
+    @Mock
+    CaseInstanceListPresenter.CaseInstanceListView view;
+
+    @Mock
+    ExtendedPagedTable<CaseInstanceSummary> pagedTable;
+
+    @Mock
+    EventSourceMock<CaseCancelEvent> caseCancelEvent;
+
+    @Mock
+    EventSourceMock<CaseDestroyEvent> caseDestroyEvent;
+
+    @InjectMocks
+    CaseInstanceListPresenter presenter;
+
+    @Before
+    public void init() {
+        casesService = new CallerMock<>(caseManagementService);
+        presenter.setCasesService(casesService);
+        presenter.setCaseCancelEvent(caseCancelEvent);
+        presenter.setCaseDestroyEvent(caseDestroyEvent);
+        when(view.getListGrid()).thenReturn(pagedTable);
+    }
+
+    @Test
+    public void testCancelCaseInstance() {
+        final String serverTemplateId = "serverTemplateId";
+        when(serverTemplateSelectorMenuBuilder.getSelectedServerTemplate()).thenReturn(serverTemplateId);
+
+        presenter.onOpen();
+        final CaseInstanceSummary cis = new CaseInstanceSummary("caseId", "description", 0, "containerId");
+        presenter.cancelCaseInstance(cis);
+
+        verify(caseManagementService).cancelCaseInstance(serverTemplateId, cis.getContainerId(), cis.getCaseId());
+        final ArgumentCaptor<CaseCancelEvent> captor = ArgumentCaptor.forClass(CaseCancelEvent.class);
+        verify(caseCancelEvent).fire(captor.capture());
+        assertEquals(cis.getCaseId(), captor.getValue().getCaseId());
+        verify(pagedTable).setVisibleRangeAndClearData(any(Range.class), anyBoolean());
+    }
+
+    @Test
+    public void testDestroyCaseInstance() {
+        final String serverTemplateId = "serverTemplateId";
+        when(serverTemplateSelectorMenuBuilder.getSelectedServerTemplate()).thenReturn(serverTemplateId);
+
+        presenter.onOpen();
+        final CaseInstanceSummary cis = new CaseInstanceSummary("caseId", "description", 0, "containerId");
+        presenter.destroyCaseInstance(cis);
+
+        verify(caseManagementService).destroyCaseInstance(serverTemplateId, cis.getContainerId(), cis.getCaseId());
+        final ArgumentCaptor<CaseDestroyEvent> captor = ArgumentCaptor.forClass(CaseDestroyEvent.class);
+        verify(caseDestroyEvent).fire(captor.capture());
+        assertEquals(cis.getCaseId(), captor.getValue().getCaseId());
+        verify(pagedTable).setVisibleRangeAndClearData(any(Range.class), anyBoolean());
+    }
+
+    @Test
+    public void testGetData() {
+        final String serverTemplateId = "serverTemplateId";
+        when(serverTemplateSelectorMenuBuilder.getSelectedServerTemplate()).thenReturn(serverTemplateId);
+
+        presenter.onOpen();
+
+        final CaseInstanceSummary cis = new CaseInstanceSummary("caseId", "description", 0, "containerId");
+        when(caseManagementService.getCaseInstances(serverTemplateId, 0, 10)).thenReturn(Arrays.asList(cis));
+        final Range range = new Range(0, 10);
+        presenter.getData(range);
+
+        verify(caseManagementService).getCaseInstances(serverTemplateId, 0, 10);
+        verify(view).hideBusyIndicator();
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/test/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstancePresenterTest.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/test/java/org/jbpm/console/ng/cm/client/newcase/NewCaseInstancePresenterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.console.ng.cm.client.newcase;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
+import org.jbpm.console.ng.cm.model.CaseDefinitionSummary;
+import org.jbpm.console.ng.cm.model.events.CaseCreatedEvent;
+import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NewCaseInstancePresenterTest {
+
+    @Mock
+    EventSourceMock<NotificationEvent> notificationEvent;
+
+    @Mock
+    EventSourceMock<CaseCreatedEvent> caseCreatedEvent;
+
+    @Mock
+    NewCaseInstancePresenter.NewCaseInstanceView view;
+
+    Caller<CaseManagementService> caseService;
+
+    @Mock
+    CaseManagementService caseManagementService;
+
+    @InjectMocks
+    NewCaseInstancePresenter presenter;
+
+    @Before
+    public void init() {
+        caseService = new CallerMock<>(caseManagementService);
+        presenter.setCaseService(caseService);
+        presenter.setNotification(notificationEvent);
+        presenter.setNewCaseEvent(caseCreatedEvent);
+    }
+
+    @Test
+    public void testCreateInvalidCaseInstance() {
+        presenter.createCaseInstance(null);
+
+        final ArgumentCaptor<NotificationEvent> captor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(notificationEvent).fire(captor.capture());
+
+        assertEquals(1, captor.getAllValues().size());
+        assertEquals(NotificationEvent.NotificationType.ERROR, captor.getValue().getType());
+    }
+
+    @Test
+    public void testCreateCaseInstance() {
+        final String serverTemplateId = "serverTemplateId";
+        final CaseDefinitionSummary cds = new CaseDefinitionSummary("id", "name", "containerId");
+        when(caseManagementService.getCaseDefinitions(serverTemplateId, 0, Integer.MAX_VALUE)).thenReturn(Arrays.asList(cds));
+
+        presenter.show(serverTemplateId);
+
+        verify(view).clearCaseDefinitions();
+        final ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(view).addCaseDefinitions(captor.capture());
+        final List list = captor.getValue();
+        assertEquals(1, list.size());
+        assertEquals(cds.getName(), list.get(0));
+        verify(view).show();
+
+        presenter.createCaseInstance(cds.getName());
+
+        verify(caseManagementService).startCaseInstance(serverTemplateId, cds.getContainerId(), cds.getCaseDefinitionId());
+        verify(view).hide();
+        verify(notificationEvent).fire(any(NotificationEvent.class));
+        verify(caseCreatedEvent).fire(any(CaseCreatedEvent.class));
+    }
+
+}

--- a/jbpm-console-ng-case-mgmt/pom.xml
+++ b/jbpm-console-ng-case-mgmt/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-console-ng</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jbpm-console-ng-case-mgmt</artifactId>
+  <packaging>pom</packaging>
+
+  <name>jBPM Console NG - Case Management</name>
+
+  <modules>
+    <module>jbpm-console-ng-case-mgmt-api</module>
+    <module>jbpm-console-ng-case-mgmt-client</module>
+    <module>jbpm-console-ng-case-mgmt-backend</module>
+  </modules>
+
+</project>

--- a/jbpm-console-ng-generic/jbpm-console-ng-generic-api/src/main/java/org/jbpm/console/ng/ga/model/GenericSummary.java
+++ b/jbpm-console-ng-generic/jbpm-console-ng-generic-api/src/main/java/org/jbpm/console/ng/ga/model/GenericSummary.java
@@ -26,6 +26,14 @@ public class GenericSummary extends AbstractPageRow implements Serializable {
     protected Object id;
     protected String name;
 
+    public GenericSummary() {
+    }
+
+    public GenericSummary(final Object id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Object getId() {
         return id;
     }
@@ -43,11 +51,14 @@ public class GenericSummary extends AbstractPageRow implements Serializable {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidMultipleUnaryOperators")
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = ~~result;
         result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = ~~result;
         return result;
     }
 
@@ -73,4 +84,11 @@ public class GenericSummary extends AbstractPageRow implements Serializable {
         return true;
     }
 
+    @Override
+    public String toString() {
+        return "GenericSummary{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
 }

--- a/jbpm-console-ng-showcase/pom.xml
+++ b/jbpm-console-ng-showcase/pom.xml
@@ -200,7 +200,6 @@
         </dependency>
 
         <!-- jBPM Console Panels -->
-
         <dependency>
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-console-ng-bpm-home-client</artifactId>
@@ -264,7 +263,6 @@
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-console-ng-process-runtime-admin-backend</artifactId>
         </dependency>
-
 
         <dependency>
             <groupId>org.jbpm</groupId>
@@ -397,6 +395,21 @@
         <dependency>
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-form-modeler-document</artifactId>
+        </dependency>
+
+        <!-- Case Management -->
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-console-ng-case-mgmt-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-console-ng-case-mgmt-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-console-ng-case-mgmt-backend</artifactId>
         </dependency>
 
         <!-- jBPM Designer -->
@@ -1174,6 +1187,8 @@
                         <compileSourcesArtifact>org.jbpm:jbpm-console-ng-workbench-integration-client</compileSourcesArtifact>
                         <compileSourcesArtifact>org.jbpm:jbpm-console-ng-executor-service-client</compileSourcesArtifact>
                         <compileSourcesArtifact>org.jbpm:jbpm-console-ng-executor-service-api</compileSourcesArtifact>
+                        <compileSourcesArtifact>org.jbpm:jbpm-console-ng-case-mgmt-client</compileSourcesArtifact>
+                        <compileSourcesArtifact>org.jbpm:jbpm-console-ng-case-mgmt-api</compileSourcesArtifact>
 
                         <!-- Dashbuilder -->
                         <compileSourcesArtifact>org.dashbuilder:dashbuilder-json</compileSourcesArtifact>
@@ -1263,7 +1278,7 @@
                                 <include>src/main/webapp/WEB-INF/tlds/</include>
                                 <include>**/gwt-unitCache/**</include>
                                 <include>.errai/</include>
-                                <!--<include>.niogit/**</include> exclude it for not so server templates are not removed-->
+                                <include>.niogit/**</include>
                                 <include>.index/**</include>
                             </includes>
                         </fileset>

--- a/jbpm-console-ng-showcase/src/main/java/org/jbpm/console/ng/client/ShowcaseEntryPoint.java
+++ b/jbpm-console-ng-showcase/src/main/java/org/jbpm/console/ng/client/ShowcaseEntryPoint.java
@@ -30,6 +30,7 @@ import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.jbpm.console.ng.client.i18n.Constants;
+import org.jbpm.console.ng.cm.client.perspectives.CaseInstanceListPerspective;
 import org.jbpm.dashboard.renderer.service.DashboardURLBuilder;
 import org.kie.workbench.common.screens.search.client.menu.SearchMenuBuilder;
 import org.kie.workbench.common.services.shared.service.PlaceManagerActivityService;
@@ -108,7 +109,7 @@ public class ShowcaseEntryPoint extends DefaultWorkbenchEntryPoint {
     protected List<? extends MenuItem> getCaseManagementViews() {
         final List<MenuItem> result = new ArrayList<>( 1 );
 
-        result.add( MenuFactory.newSimpleItem( constants.Cases() ).perspective( "Cases" ).endMenu().build().getItems().get( 0 ) );
+        result.add( MenuFactory.newSimpleItem( constants.Cases() ).perspective( CaseInstanceListPerspective.PERSPECTIVE_ID ).endMenu().build().getItems().get( 0 ) );
 
         return result;
     }

--- a/jbpm-console-ng-showcase/src/main/resources/org/jbpm/console/ng/jBPMShowcase.gwt.xml
+++ b/jbpm-console-ng-showcase/src/main/resources/org/jbpm/console/ng/jBPMShowcase.gwt.xml
@@ -58,8 +58,8 @@
 
 
   <!-- jbpm-wb -->
-  <!--inherits name="org.jbpm.console.ng.cm.JbpmConsoleNGCaseMgmtAPI"/>
-  <inherits name="org.jbpm.console.ng.cm.JbpmConsoleNGCaseMgmtClient"/-->
+  <inherits name="org.jbpm.console.ng.cm.JbpmConsoleNGCaseMgmtAPI"/>
+  <inherits name="org.jbpm.console.ng.cm.JbpmConsoleNGCaseMgmtClient"/>
   <inherits name="org.jbpm.console.ng.bh.JbpmConsoleNGBPMHomeClient"/>
   <inherits name="org.jbpm.console.ng.ht.JbpmConsoleNGHumanTasksClient"/>
   <inherits name="org.jbpm.console.ng.ht.forms.JbpmConsoleNGHumanTasksFormsClient"/>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <module>jbpm-console-ng-dashboard</module>
     <module>jbpm-console-ng-generic</module>
     <module>jbpm-console-ng-documents</module>
+    <module>jbpm-console-ng-case-mgmt</module>
     <module>jbpm-console-ng-showcase</module>
   </modules>
 


### PR DESCRIPTION
New perspective and related modules for handling starting and closing/destroy cases.
Interaction with kie-server new API for case management,
Only adding it to jbpm-console-ng-showcase until feature complete.

Depends on: https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/272

How to test it:

- Start both jbpm-console-ng and latest kie-server (includes Case Management remote API)
- Author Evaluation project and update evaluation process as ad-hoc=true (Or any other project, as long as there are cases deployment to the current kie-server instance).
- Deploy Evaluation project into Kie-Server
- Navigate to Cases perspective where you will be able to start a new case ( based on Evaluation definition) as well as close or destroy any existing case instance.