### PR TITLE
JBPM-5061: Jobs perpertive replaces all tab with queued when the user…

### DIFF
--- a/jbpm-console-ng-executor-service/jbpm-console-ng-executor-service-client/src/main/java/org/jbpm/console/ng/es/client/editors/requestlist/RequestListViewImpl.java
+++ b/jbpm-console-ng-executor-service/jbpm-console-ng-executor-service-client/src/main/java/org/jbpm/console/ng/es/client/editors/requestlist/RequestListViewImpl.java
@@ -550,7 +550,7 @@ public class RequestListViewImpl extends AbstractMultiGridView<RequestSummary, R
         if (tabSettingsValues != null) {
             tabSettingsValues.put(NewTabFilterPopup.FILTER_TAB_NAME_PARAM, constants.Queued());
             tabSettingsValues.put(NewTabFilterPopup.FILTER_TAB_DESC_PARAM, constants.FilterQueued());
-            filterPagedTable.saveTabSettings(REQUEST_LIST_PREFIX + "_0", tabSettingsValues);
+            filterPagedTable.saveTabSettings(REQUEST_LIST_PREFIX + "_1", tabSettingsValues);
         }
 
         tabSettingsValues = filterPagedTable.getMultiGridPreferencesStore().getGridSettings(REQUEST_LIST_PREFIX + "_2");

--- a/jbpm-console-ng-executor-service/jbpm-console-ng-executor-service-client/src/test/java/org/jbpm/console/ng/es/client/editors/requestlist/RequestListViewTest.java
+++ b/jbpm-console-ng-executor-service/jbpm-console-ng-executor-service-client/src/test/java/org/jbpm/console/ng/es/client/editors/requestlist/RequestListViewTest.java
@@ -80,6 +80,14 @@ public class RequestListViewTest {
 
         verify(filterPagedTableMock, times(7)).getMultiGridPreferencesStore();
         verify(filterPagedTableMock, times(7)).saveTabSettings(anyString(), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_0"), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_1"), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_2"), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_3"), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_4"), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_5"), any(HashMap.class));
+        verify(filterPagedTableMock).saveTabSettings(eq(RequestListViewImpl.REQUEST_LIST_PREFIX + "_6"), any(HashMap.class));
+
     }
 
     @Test


### PR DESCRIPTION
… leave and return the section.
Related to https://issues.jboss.org/browse/RHBPMS-4246.Jobs: Queued tab displays jobs in status DONE