### PR TITLE
[6.5.x] RHBPMS-4185 - Unable to use LATEST in process image REST endpoint

### DIFF
--- a/jbpm-console-ng-rest/src/main/java/org/jbpm/console/ng/rest/ProcessImageResourceImpl.java
+++ b/jbpm-console-ng-rest/src/main/java/org/jbpm/console/ng/rest/ProcessImageResourceImpl.java
@@ -123,7 +123,7 @@ public class ProcessImageResourceImpl {
         }
 
         // get SVG String
-        String imageSVGString = getProcesImageSVGFromDeployment(deploymentId, procDef);
+        String imageSVGString = getProcesImageSVGFromDeployment(procDef.getDeploymentId(), procDef);
         if( imageSVGString == null ) {
             logger.warn("Could not find SVG image file for process '" + processId + "', returning status 412 (PRECONDITION FAILED). Has the 'storesvgonsave' option in the jbpm.xml file in the war been set to true?");
             return Response.status(Response.Status.PRECONDITION_FAILED).build();
@@ -148,7 +148,7 @@ public class ProcessImageResourceImpl {
         }
 
         // get SVG String
-        String imageSVGString = getProcesImageSVGFromDeployment(deploymentId, procDef);
+        String imageSVGString = getProcesImageSVGFromDeployment(procDef.getDeploymentId(), procDef);
         if( imageSVGString == null ) {
             return Response.status(Response.Status.PRECONDITION_FAILED).build();
         }


### PR DESCRIPTION
Additional fix for [RHBPMS-4185](https://issues.jboss.org/browse/RHBPMS-4185). The problem was found and described in [RHBPMS-4188](https://issues.jboss.org/browse/RHBPMS-4188).