### PR TITLE
[JBPM-5366] replace kie-remote-common with kie-server-common

### DIFF
--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/pom.xml
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/pom.xml
@@ -167,8 +167,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.remote</groupId>
-      <artifactId>kie-remote-common</artifactId>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-common</artifactId>
     </dependency>
 
     <dependency>

--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/integration/KieServerDataSetManager.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/integration/KieServerDataSetManager.java
@@ -29,7 +29,7 @@ import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefRegistry;
 import org.dashbuilder.dataset.def.SQLDataSetDef;
 import org.jbpm.console.ng.ga.events.KieServerDataSetRegistered;
-import org.kie.remote.common.rest.KieRemoteHttpRequestException;
+import org.kie.server.common.rest.KieServerHttpRequestException;
 import org.kie.server.api.model.definition.QueryDefinition;
 import org.kie.server.client.KieServicesException;
 import org.kie.server.client.QueryServicesClient;
@@ -116,7 +116,7 @@ public class KieServerDataSetManager {
 
                 event.fire(new KieServerDataSetRegistered(serverInstanceId, serverTemplateId));
                 return;
-            } catch (KieServicesException | KieRemoteHttpRequestException e) {
+            } catch (KieServicesException | KieServerHttpRequestException e) {
                 // unable to register, might still be booting
                 Thread.sleep(500);
                 elapsed += 500;

--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/integration/KieServerDataSetProvider.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/main/java/org/jbpm/console/ng/bd/integration/KieServerDataSetProvider.java
@@ -46,7 +46,7 @@ import org.dashbuilder.dataset.sort.ColumnSort;
 import org.dashbuilder.dataset.sort.DataSetSort;
 import org.dashbuilder.dataset.sort.SortOrder;
 import org.jbpm.console.ng.ga.model.dataset.ConsoleDataSetLookup;
-import org.kie.remote.common.rest.KieRemoteHttpRequestException;
+import org.kie.server.common.rest.KieServerHttpRequestException;
 import org.kie.server.api.model.definition.QueryFilterSpec;
 import org.kie.server.api.model.definition.QueryParam;
 import org.kie.server.client.QueryServicesClient;
@@ -168,7 +168,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                     dataSetLookup.getNumberOfRows(),
                     List.class
             );
-        } catch (KieRemoteHttpRequestException e) {
+        } catch (KieServerHttpRequestException e) {
             // in case on any exception return empty data set and log error
             LOGGER.warn("Encountered {} while fetching query for {}", e.getMessage(), dataSetLookup.getDataSetUUID());
             instances = Collections.emptyList();

--- a/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/test/java/org/jbpm/console/ng/bd/integration/KieServerDataSetManagerTest.java
+++ b/jbpm-console-ng-business-domain/jbpm-console-ng-business-domain-backend/src/test/java/org/jbpm/console/ng/bd/integration/KieServerDataSetManagerTest.java
@@ -27,7 +27,7 @@ import org.jbpm.console.ng.ga.events.KieServerDataSetRegistered;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.remote.common.rest.KieRemoteHttpRequestException;
+import org.kie.server.common.rest.KieServerHttpRequestException;
 import org.kie.server.api.model.definition.QueryDefinition;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesException;
@@ -101,7 +101,7 @@ public class KieServerDataSetManagerTest {
 
     @Test
     public void testRegisterQueriesWithRetryDueToKieRemoteHttpRequestException() throws Exception {
-        registerQueriesWithRetryException(new KieRemoteHttpRequestException("KieServer endpoint down"));
+        registerQueriesWithRetryException(new KieServerHttpRequestException("KieServer endpoint down"));
     }
 
     private void registerQueriesWithRetryException(Exception exception) throws Exception {


### PR DESCRIPTION
@mswiderski we need this one as well :)

I am wondering though if console-ng should depend on this artifact? I know its used to catch the particular exception, but I am wondering if it we should be it using here, since the exception seems low level?