### PR TITLE
Reuse AbstractPresenter in Case*Presenters

### DIFF
--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/comments/CaseCommentsPresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/comments/CaseCommentsPresenter.java
@@ -22,12 +22,10 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.security.shared.api.identity.User;
-import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jbpm.console.ng.cm.client.util.AbstractCaseInstancePresenter;
 import org.jbpm.console.ng.cm.model.CaseCommentSummary;
 import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
-import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.mvp.Command;
@@ -36,25 +34,14 @@ import static org.jbpm.console.ng.cm.client.resources.i18n.Constants.*;
 
 @Dependent
 @WorkbenchScreen(identifier = CaseCommentsPresenter.SCREEN_ID)
-public class CaseCommentsPresenter extends AbstractCaseInstancePresenter {
+public class CaseCommentsPresenter extends AbstractCaseInstancePresenter<CaseCommentsPresenter.CaseCommentsView> {
 
     public static final String SCREEN_ID = "Case Comments";
-
-    @Inject
-    private CaseCommentsView caseCommentView;
-
-    @Inject
-    private TranslationService translationService;
 
     @Inject
     User identity;
 
     private String currentUpdatedCommentId = "";
-
-    @WorkbenchPartView
-    public UberElement<CaseCommentsPresenter> getView() {
-        return caseCommentView;
-    }
 
     @WorkbenchPartTitle
     public String getTittle() {
@@ -63,7 +50,7 @@ public class CaseCommentsPresenter extends AbstractCaseInstancePresenter {
 
     @Override
     protected void clearCaseInstance() {
-        caseCommentView.removeAllComments();
+        view.removeAllComments();
     }
 
     @Override
@@ -97,11 +84,11 @@ public class CaseCommentsPresenter extends AbstractCaseInstancePresenter {
 
                                 @Override
                                 public void execute() {
-                                    deleteCaseComment((String) caseCommentSummary.getId());
+                                    deleteCaseComment(caseCommentSummary.getId());
                                 }
                             };
                         }
-                        caseCommentView.addComment(editing, updateActionLabel, (String) caseCommentSummary.getId(), caseCommentSummary.getAuthor(),
+                        view.addComment(editing, updateActionLabel, caseCommentSummary.getId(), caseCommentSummary.getAuthor(),
                                 caseCommentSummary.getText(), caseCommentSummary.getAddedAt(), deleteCommentAction);
                     }
                 }

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/details/CaseDetailsPresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/details/CaseDetailsPresenter.java
@@ -15,41 +15,25 @@
  */
 package org.jbpm.console.ng.cm.client.details;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
 
 import com.google.gwt.user.client.TakesValue;
-import org.jbpm.console.ng.cm.client.util.AbstractCaseInstancePresenter;
 import org.jbpm.console.ng.cm.client.resources.i18n.Constants;
+import org.jbpm.console.ng.cm.client.util.AbstractCaseInstancePresenter;
 import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
-import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.UberElement;
 
 @Dependent
 @WorkbenchScreen(identifier = CaseDetailsPresenter.SCREEN_ID)
-public class CaseDetailsPresenter extends AbstractCaseInstancePresenter {
+public class CaseDetailsPresenter extends AbstractCaseInstancePresenter<CaseDetailsPresenter.CaseDetailsView> {
 
     public static final String SCREEN_ID = "Case Details Screen";
-
-    @Inject
-    private CaseDetailsView view;
-
-    @PostConstruct
-    public void init() {
-        view.init(this);
-    }
 
     @WorkbenchPartTitle
     public String getTitle() {
         return translationService.format(Constants.CASE_DETAILS);
-    }
-
-    @WorkbenchPartView
-    public UberElement<CaseDetailsPresenter> getView() {
-        return view;
     }
 
     @Override
@@ -65,5 +49,4 @@ public class CaseDetailsPresenter extends AbstractCaseInstancePresenter {
     public interface CaseDetailsView extends UberElement<CaseDetailsPresenter>, TakesValue<CaseInstanceSummary> {
 
     }
-
 }

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/overview/CaseOverviewPresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/overview/CaseOverviewPresenter.java
@@ -16,13 +16,10 @@
 package org.jbpm.console.ng.cm.client.overview;
 
 import java.util.Map;
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import org.jboss.errai.ui.client.local.spi.TranslationService;
-import org.jbpm.console.ng.cm.client.util.AbstractCaseInstancePresenter;
 import org.jbpm.console.ng.cm.client.comments.CaseCommentsPresenter;
 import org.jbpm.console.ng.cm.client.details.CaseDetailsPresenter;
 import org.jbpm.console.ng.cm.client.events.CaseCancelEvent;
@@ -30,9 +27,9 @@ import org.jbpm.console.ng.cm.client.events.CaseDestroyEvent;
 import org.jbpm.console.ng.cm.client.events.CaseRefreshEvent;
 import org.jbpm.console.ng.cm.client.perspectives.CaseInstanceListPerspective;
 import org.jbpm.console.ng.cm.client.roles.CaseRolesPresenter;
+import org.jbpm.console.ng.cm.client.util.AbstractCaseInstancePresenter;
 import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
-import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberElement;
@@ -42,34 +39,18 @@ import static org.jbpm.console.ng.cm.client.resources.i18n.Constants.*;
 
 @Dependent
 @WorkbenchScreen(identifier = CaseOverviewPresenter.SCREEN_ID)
-public class CaseOverviewPresenter extends AbstractCaseInstancePresenter {
+public class CaseOverviewPresenter extends AbstractCaseInstancePresenter<CaseOverviewPresenter.CaseOverviewView> {
 
     public static final String SCREEN_ID = "Case Overview";
 
     @Inject
     PlaceManager placeManager;
 
-    @Inject
-    private CaseOverviewView view;
-
-    @Inject
-    private TranslationService translationService;
-
     private Event<CaseCancelEvent> caseCancelEvent;
 
     private Event<CaseDestroyEvent> caseDestroyEvent;
 
     private Event<CaseRefreshEvent> caseRefreshEvent;
-
-    @PostConstruct
-    public void init() {
-        view.init(this);
-    }
-
-    @WorkbenchPartView
-    public UberElement<CaseOverviewPresenter> getView() {
-        return view;
-    }
 
     @WorkbenchPartTitle
     public String getTitle() {
@@ -80,7 +61,7 @@ public class CaseOverviewPresenter extends AbstractCaseInstancePresenter {
     public void onOpen() {
         view.addCaseDetails(CaseDetailsPresenter.SCREEN_ID, place.getParameters());
         view.addCaseRoles(CaseRolesPresenter.SCREEN_ID, place.getParameters());
-        view.addCaseComments(CaseCommentsPresenter.SCREEN_ID,place.getParameters());
+        view.addCaseComments(CaseCommentsPresenter.SCREEN_ID, place.getParameters());
     }
 
     protected void refreshCase() {

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRolesPresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRolesPresenter.java
@@ -21,12 +21,10 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jbpm.console.ng.cm.client.util.AbstractCaseInstancePresenter;
 import org.jbpm.console.ng.cm.model.CaseDefinitionSummary;
 import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
-import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.mvp.Command;
@@ -35,23 +33,12 @@ import static org.jbpm.console.ng.cm.client.resources.i18n.Constants.*;
 
 @Dependent
 @WorkbenchScreen(identifier = CaseRolesPresenter.SCREEN_ID)
-public class CaseRolesPresenter extends AbstractCaseInstancePresenter {
+public class CaseRolesPresenter extends AbstractCaseInstancePresenter<CaseRolesPresenter.CaseRolesView> {
 
     public static final String SCREEN_ID = "Case Roles";
 
     @Inject
-    private CaseRolesView caseRolesView;
-
-    @Inject
     private NewRoleAssignmentView newRoleAssignmentView;
-
-    @Inject
-    private TranslationService translationService;
-
-    @WorkbenchPartView
-    public UberElement<CaseRolesPresenter> getView() {
-        return caseRolesView;
-    }
 
     @WorkbenchPartTitle
     public String getTittle() {
@@ -60,13 +47,13 @@ public class CaseRolesPresenter extends AbstractCaseInstancePresenter {
 
     @Override
     protected void clearCaseInstance() {
-        caseRolesView.disableNewRoleAssignments();
-        caseRolesView.removeAllRoles();
+        view.disableNewRoleAssignments();
+        view.removeAllRoles();
     }
 
     @Override
     protected void loadCaseInstance(final CaseInstanceSummary cis) {
-        caseRolesView.addUser(cis.getOwner(), translationService.format(OWNER));
+        view.addUser(cis.getOwner(), translationService.format(OWNER));
 
         setupRoleAssignments(cis);
 
@@ -85,10 +72,10 @@ public class CaseRolesPresenter extends AbstractCaseInstancePresenter {
                         return;
                     }
 
-                    caseRolesView.enableNewRoleAssignments();
+                    view.enableNewRoleAssignments();
 
-                    caseRolesView.setUserAddCommand(() -> newRoleAssignmentView.show(true, roles, () -> addUserToRole(newRoleAssignmentView.getUserName(), newRoleAssignmentView.getRoleName())));
-                    caseRolesView.setGroupAddCommand(() -> newRoleAssignmentView.show(false, roles, () -> addGroupToRole(newRoleAssignmentView.getUserName(), newRoleAssignmentView.getRoleName())));
+                    view.setUserAddCommand(() -> newRoleAssignmentView.show(true, roles, () -> addUserToRole(newRoleAssignmentView.getUserName(), newRoleAssignmentView.getRoleName())));
+                    view.setGroupAddCommand(() -> newRoleAssignmentView.show(false, roles, () -> addGroupToRole(newRoleAssignmentView.getUserName(), newRoleAssignmentView.getRoleName())));
                 }
         ).getCaseDefinition(serverTemplateId, containerId, cis.getCaseDefinitionId());
     }
@@ -96,7 +83,7 @@ public class CaseRolesPresenter extends AbstractCaseInstancePresenter {
     protected Set<String> getRolesAvailableForAssignment(final CaseInstanceSummary cis, final CaseDefinitionSummary cds) {
         return cds.getRoles().keySet().stream().filter(
                 role -> {
-                    if("owner".equals(role)){
+                    if ("owner".equals(role)) {
                         return false;
                     }
                     final Integer roleCardinality = cds.getRoles().get(role);
@@ -116,7 +103,7 @@ public class CaseRolesPresenter extends AbstractCaseInstancePresenter {
 
         cis.getRoleAssignments().forEach(
                 crs -> {
-                    crs.getUsers().forEach(user -> caseRolesView.addUser(user, crs.getName(), new CaseRoleAction() {
+                    crs.getUsers().forEach(user -> view.addUser(user, crs.getName(), new CaseRoleAction() {
 
                         @Override
                         public String label() {
@@ -128,7 +115,7 @@ public class CaseRolesPresenter extends AbstractCaseInstancePresenter {
                             removeUserFromRole(user, crs.getName());
                         }
                     }));
-                    crs.getGroups().forEach(group -> caseRolesView.addGroup(group, crs.getName(), new CaseRoleAction() {
+                    crs.getGroups().forEach(group -> view.addGroup(group, crs.getName(), new CaseRoleAction() {
 
                         @Override
                         public String label() {

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/util/AbstractCaseInstancePresenter.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/util/AbstractCaseInstancePresenter.java
@@ -24,12 +24,13 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jbpm.console.ng.cm.client.events.CaseRefreshEvent;
 import org.jbpm.console.ng.cm.model.CaseInstanceSummary;
 import org.jbpm.console.ng.cm.service.CaseManagementService;
+import org.uberfire.client.mvp.UberElement;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
 
 import static com.google.common.base.Strings.*;
 
-public abstract class AbstractCaseInstancePresenter {
+public abstract class AbstractCaseInstancePresenter<V extends UberElement> extends AbstractPresenter<V> {
 
     public static final String PARAMETER_CASE_ID = "caseId";
     public static final String PARAMETER_SERVER_TEMPLATE_ID = "serverTemplateId";

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/test/java/org/jbpm/console/ng/cm/client/roles/CaseRolesPresenterTest.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/test/java/org/jbpm/console/ng/cm/client/roles/CaseRolesPresenterTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.*;
 public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
 
     @Mock
-    CaseRolesPresenter.CaseRolesView caseRolesView;
+    CaseRolesPresenter.CaseRolesView view;
 
     @Mock
     CaseRolesPresenter.NewRoleAssignmentView assignmentView;
@@ -66,8 +66,8 @@ public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
     }
 
     private void verifyClearCaseInstance() {
-        verify(caseRolesView).removeAllRoles();
-        verify(caseRolesView).disableNewRoleAssignments();
+        verify(view).removeAllRoles();
+        verify(view).disableNewRoleAssignments();
     }
 
     @Test
@@ -87,26 +87,26 @@ public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
         setupCaseInstance(cis, serverTemplateId);
 
         verifyClearCaseInstance();
-        verify(caseRolesView).addUser(cis.getOwner(), "Owner");
+        verify(view).addUser(cis.getOwner(), "Owner");
 
         final ArgumentCaptor<CaseRolesPresenter.CaseRoleAction> captor = ArgumentCaptor.forClass(CaseRolesPresenter.CaseRoleAction.class);
-        verify(caseRolesView).addUser(eq(userName), eq(roleName), captor.capture());
+        verify(view).addUser(eq(userName), eq(roleName), captor.capture());
         assertEquals("Remove", captor.getValue().label());
-        verify(caseRolesView).addGroup(eq(groupName), eq(roleName), captor.capture());
+        verify(view).addGroup(eq(groupName), eq(roleName), captor.capture());
         assertEquals("Remove", captor.getValue().label());
 
-        verify(caseRolesView).enableNewRoleAssignments();
-        verify(caseRolesView).setUserAddCommand(any(Command.class));
-        verify(caseRolesView).setGroupAddCommand(any(Command.class));
+        verify(view).enableNewRoleAssignments();
+        verify(view).setUserAddCommand(any(Command.class));
+        verify(view).setGroupAddCommand(any(Command.class));
     }
 
     @Test
     public void testSetupRoleAssignmentsEmpty() {
         presenter.setupRoleAssignments(CaseInstanceSummary.builder().build());
 
-        verify(caseRolesView, never()).addUser(anyString(), anyString());
-        verify(caseRolesView, never()).addGroup(anyString(), anyString());
-        verifyNoMoreInteractions(caseRolesView);
+        verify(view, never()).addUser(anyString(), anyString());
+        verify(view, never()).addGroup(anyString(), anyString());
+        verifyNoMoreInteractions(view);
     }
 
     @Test
@@ -119,10 +119,10 @@ public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
         presenter.setupRoleAssignments(cis);
 
         final ArgumentCaptor<CaseRolesPresenter.CaseRoleAction> captor = ArgumentCaptor.forClass(CaseRolesPresenter.CaseRoleAction.class);
-        verify(caseRolesView).addUser(eq(userName), eq(roleName), captor.capture());
+        verify(view).addUser(eq(userName), eq(roleName), captor.capture());
         assertEquals("Remove", captor.getValue().label());
-        verify(caseRolesView, never()).addGroup(anyString(), anyString());
-        verifyNoMoreInteractions(caseRolesView);
+        verify(view, never()).addGroup(anyString(), anyString());
+        verifyNoMoreInteractions(view);
 
         captor.getValue().execute();
         verify(caseManagementService).removeUserFromRole(anyString(), anyString(), anyString(), eq(roleName), eq(userName));
@@ -139,10 +139,10 @@ public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
         presenter.setupRoleAssignments(cis);
 
         final ArgumentCaptor<CaseRolesPresenter.CaseRoleAction> captor = ArgumentCaptor.forClass(CaseRolesPresenter.CaseRoleAction.class);
-        verify(caseRolesView).addGroup(eq(groupName), eq(roleName), captor.capture());
+        verify(view).addGroup(eq(groupName), eq(roleName), captor.capture());
         assertEquals("Remove", captor.getValue().label());
-        verify(caseRolesView, never()).addUser(anyString(), anyString());
-        verifyNoMoreInteractions(caseRolesView);
+        verify(view, never()).addUser(anyString(), anyString());
+        verifyNoMoreInteractions(view);
 
         captor.getValue().execute();
         verify(caseManagementService).removeGroupFromRole(anyString(), anyString(), anyString(), eq(roleName), eq(groupName));
@@ -157,8 +157,8 @@ public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
 
         presenter.setupNewRoleAssignments(cis);
 
-        verify(caseRolesView, never()).enableNewRoleAssignments();
-        verifyNoMoreInteractions(caseRolesView);
+        verify(view, never()).enableNewRoleAssignments();
+        verifyNoMoreInteractions(view);
     }
 
     @Test
@@ -171,16 +171,16 @@ public class CaseRolesPresenterTest extends AbstractCaseInstancePresenterTest {
 
         presenter.setupNewRoleAssignments(cis);
 
-        verify(caseRolesView).enableNewRoleAssignments();
+        verify(view).enableNewRoleAssignments();
         final ArgumentCaptor<Command> captor = ArgumentCaptor.forClass(Command.class);
-        verify(caseRolesView).setUserAddCommand(captor.capture());
+        verify(view).setUserAddCommand(captor.capture());
         captor.getValue().execute();
         final ArgumentCaptor<Command> okCommandCaptor = ArgumentCaptor.forClass(Command.class);
         verify(assignmentView).show(eq(true), eq(singleton(roleName)), okCommandCaptor.capture());
         okCommandCaptor.getValue().execute();
         verify(caseManagementService).assignUserToRole(anyString(), anyString(), anyString(), anyString(), anyString());
 
-        verify(caseRolesView).setGroupAddCommand(captor.capture());
+        verify(view).setGroupAddCommand(captor.capture());
         captor.getValue().execute();
         verify(assignmentView).show(eq(false), eq(singleton(roleName)), okCommandCaptor.capture());
         okCommandCaptor.getValue().execute();


### PR DESCRIPTION
Take advantage of existing AbstractPresenter class to initialize connection between view and presenter.

The change required making `AbstractCaseInstancePresenter` extend the generic `AbstractPresenter` and renaming the `viewXYZ` fields in the subclasses to `view` so it is inherited from `AbstractPresenter`. 

Also removed some duplicated TranslationService fields in the subclasses which are alreade declared as protected in `AbstractCaseInstancePresenter`.

UPDATE: also removed `@PostConstruct` methods for initializing view which are no longer necessary.