### PR TITLE
Fix user/group name and role name positioning

### DIFF
--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRoleItemView.css
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRoleItemView.css
@@ -1,0 +1,8 @@
+.kie-roles-description {
+    display: block;
+}
+
+.kie-roles-description .list-group-item-heading,
+.kie-roles-description .list-group-item-text {
+    width: inherit;
+}

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRoleItemView.html
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRoleItemView.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <div class="list-group-item">
-    <div class="list-view-pf-actions" data-field="user-actions" style="min-width: 15px;">
+    <div class="list-view-pf-actions" data-field="user-actions">
         <div class="dropdown pull-right dropdown-kebab-pf hidden" data-field="actions-dropdown">
             <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight9" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <span class="fa fa-ellipsis-v"></span>
@@ -9,11 +9,11 @@
         </div>
     </div>
     <div class="list-view-pf-main-info">
-        <div class="list-view-pf-left" style="width: 45px;">
+        <div class="list-view-pf-left">
             <span class="pficon" data-field="icon-type"></span>
         </div>
         <div class="list-view-pf-body">
-            <div class="list-view-pf-description">
+            <div class="list-view-pf-description kie-roles-description">
                 <div class="list-group-item-heading"><span data-field="name"></span></div>
                 <div class="list-group-item-text"><span data-field="role-name"></span></div>
             </div>

--- a/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRoleItemView.java
+++ b/jbpm-console-ng-case-mgmt/jbpm-console-ng-case-mgmt-client/src/main/java/org/jbpm/console/ng/cm/client/roles/CaseRoleItemView.java
@@ -32,7 +32,7 @@ import static org.jboss.errai.common.client.dom.DOMUtil.removeCSSClass;
 import static org.jboss.errai.common.client.dom.Window.getDocument;
 
 @Dependent
-@Templated
+@Templated(stylesheet = "CaseRoleItemView.css")
 public class CaseRoleItemView implements IsElement {
 
     @Inject


### PR DESCRIPTION
Avoid overflow by positioning user/group name on top of role name instead of side by side.