### PR TITLE
JBPM-4246: Jobs: Queued tab displays jobs in status DONE

### DIFF
--- a/jbpm-console-ng-executor-service/jbpm-console-ng-executor-service-client/src/main/java/org/jbpm/console/ng/es/client/editors/requestlist/RequestListPresenter.java
+++ b/jbpm-console-ng-executor-service/jbpm-console-ng-executor-service-client/src/main/java/org/jbpm/console/ng/es/client/editors/requestlist/RequestListPresenter.java
@@ -168,7 +168,7 @@ public class RequestListPresenter extends AbstractScreenListPresenter<RequestSum
                     dataSetQueryHelper.lookupDataSet(visibleRange.getStart(), new AbstractDataSetReadyCallback( errorPopup, view, currentTableSettings.getDataSet() ) {
                         @Override
                         public void callback(DataSet dataSet) {
-                            if (dataSet != null) {
+                            if (dataSet != null && dataSetQueryHelper.getCurrentTableSettings().getKey().equals(currentTableSettings.getKey())) {
                                 List<RequestSummary> myRequestSumaryFromDataSet = new ArrayList<RequestSummary>();
 
                                 for (int i = 0; i < dataSet.getRowCount(); i++) {

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/AbstractTasksListGridPresenter.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/main/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/AbstractTasksListGridPresenter.java
@@ -217,7 +217,7 @@ public abstract class AbstractTasksListGridPresenter extends AbstractScreenListP
 
             @Override
             public void callback(DataSet dataSet) {
-                if (dataSet != null) {
+                if (dataSet != null && dataSetQueryHelper.getCurrentTableSettings().getKey().equals(tableSettings.getKey())) {
                     final List<TaskSummary> myTasksFromDataSet = new ArrayList<TaskSummary>();
 
                     for (int i = 0; i < dataSet.getRowCount(); i++) {

--- a/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/test/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/AbstractTasksListGridPresenterTest.java
+++ b/jbpm-console-ng-human-tasks/jbpm-console-ng-human-tasks-client/src/test/java/org/jbpm/console/ng/ht/client/editors/taskslist/grid/AbstractTasksListGridPresenterTest.java
@@ -121,6 +121,8 @@ public abstract class AbstractTasksListGridPresenterTest {
         when(viewMock.getVariablesTableSettings(anyString())).thenReturn(new DataSetTasksListGridViewImpl().getVariablesTableSettings("taskName"));
         when(extendedPagedTable.getPageSize()).thenReturn(10);
         when(dataSetQueryHelper.getCurrentTableSettings()).thenReturn(filterSettings);
+        when(filterSettings.getKey()).thenReturn("key");
+
 
         //Mock that actually calls the callbacks
         doAnswer(new Answer() {

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/list/variables/dash/DataSetProcessInstanceWithVariablesListPresenter.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/main/java/org/jbpm/console/ng/pr/client/editors/instance/list/variables/dash/DataSetProcessInstanceWithVariablesListPresenter.java
@@ -243,7 +243,7 @@ public class DataSetProcessInstanceWithVariablesListPresenter extends AbstractSc
             @Override
             public void callback( DataSet dataSet ) {
 
-                if ( dataSet != null ) {
+                if ( dataSet != null && dataSetQueryHelper.getCurrentTableSettings().getKey().equals(tableSettings.getKey())) {
 
                     myProcessInstancesFromDataSet.clear();
                     for ( int i = 0; i < dataSet.getRowCount(); i++ ) {

--- a/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/test/java/org/jbpm/console/ng/pr/client/editors/instance/list/variables/dash/DataSetProcessInstanceWithVariablesListPresenterTest.java
+++ b/jbpm-console-ng-process-runtime/jbpm-console-ng-process-runtime-client/src/test/java/org/jbpm/console/ng/pr/client/editors/instance/list/variables/dash/DataSetProcessInstanceWithVariablesListPresenterTest.java
@@ -108,6 +108,7 @@ public class DataSetProcessInstanceWithVariablesListPresenterTest {
         when(extendedPagedTable.getPageSize()).thenReturn(10);
         when(dataSetQueryHelper.getCurrentTableSettings()).thenReturn(filterSettings);
         when(viewMock.getVariablesTableSettings("testProc")).thenReturn(filterSettings);
+        when(filterSettings.getKey()).thenReturn("key");
 
         doAnswer(new Answer() {
 


### PR DESCRIPTION
Added a check before the data is loaded in table rows to verify that the results match with the last tab  requested to avoid fill data with previous request. 