### PR TITLE
PLANNER-707: Workbench "import example dialog": Embed stock example repositories

### DIFF
--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -699,6 +699,26 @@
             <artifactId>kie-wb-common-library-backend</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.kie.workbench.screens</groupId>
+            <artifactId>kie-wb-common-examples-screen-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kie.workbench.screens</groupId>
+            <artifactId>kie-wb-common-examples-screen-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kie.workbench.screens</groupId>
+            <artifactId>kie-wb-common-examples-screen-backend</artifactId>
+        </dependency>
+
+        <!-- KIE Workbench Playground Repository -->
+        <dependency>
+            <groupId>org.kie.workbench.playground</groupId>
+            <artifactId>playground-parent</artifactId>
+        </dependency>
+
         <!-- Needed for the Deployment Descriptor Editor -->
         <dependency>
             <groupId>org.drools</groupId>
@@ -1222,6 +1242,8 @@
                         <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-workbench-client</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-library-client</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-library-api</compileSourcesArtifact>
+                        <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-examples-screen-api</compileSourcesArtifact>
+                        <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-examples-screen-client</compileSourcesArtifact>
 
                         <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-api</compileSourcesArtifact>
                         <compileSourcesArtifact>org.drools:drools-wb-workitems-editor-client</compileSourcesArtifact>

--- a/jbpm-wb-showcase/src/main/java/org/jbpm/workbench/client/perspectives/ProjectAuthoringPerspective.java
+++ b/jbpm-wb-showcase/src/main/java/org/jbpm/workbench/client/perspectives/ProjectAuthoringPerspective.java
@@ -16,6 +16,7 @@
 
 package org.jbpm.workbench.client.perspectives;
 
+import org.kie.workbench.common.screens.examples.client.wizard.ExamplesWizard;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcesMenu;
 import org.kie.workbench.common.widgets.client.menu.RepositoryMenu;
 import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
@@ -53,6 +54,9 @@ public class ProjectAuthoringPerspective {
     @Inject
     private AuthoringWorkbenchDocks docks;
 
+    @Inject
+    private ExamplesWizard wizard;
+
     @PostConstruct
     public void setup() {
         docks.setup("Authoring", new DefaultPlaceRequest("org.kie.guvnor.explorer"));
@@ -69,6 +73,15 @@ public class ProjectAuthoringPerspective {
     @WorkbenchMenu
     public Menus getMenus() {
         return MenuFactory
+                .newTopLevelMenu( "Examples" )
+                .respondsWith( new Command() {
+                    @Override
+                    public void execute() {
+                        wizard.start();
+                    }
+                } )
+                .endMenu()
+
                 .newTopLevelMenu("Projects")
                 .respondsWith(new Command() {
                     @Override

--- a/jbpm-wb-showcase/src/main/java/org/jbpm/workbench/server/impl/AppSetup.java
+++ b/jbpm-wb-showcase/src/main/java/org/jbpm/workbench/server/impl/AppSetup.java
@@ -65,21 +65,10 @@ public class AppSetup extends BaseAppSetup {
     @PostConstruct
     public void onStartup() {
         if ( !"false".equalsIgnoreCase( System.getProperty( "org.kie.demo" ) ) ) {
-            final Repository repository = createRepository(JBPM_WB_PLAYGROUND_ALIAS, GIT_SCHEME, JBPM_WB_PLAYGROUND_ORIGIN, "", "");
-            createOU(repository, OU_NAME, OU_OWNER);
-        } else if ( "true".equalsIgnoreCase( System.getProperty( "org.kie.example" ) ) ) {
-            final Repository repository = createRepository( "repository1", GIT_SCHEME, null, "", "" );
-
-            createOU( repository,
-                    "example",
-                    "" );
-
-            createProject( repository,
-                    "org.kie.example",
-                    "project1",
-                    "1.0.0-SNAPSHOT" );
+            final Repository repository = createRepository( JBPM_WB_PLAYGROUND_ALIAS, GIT_SCHEME, JBPM_WB_PLAYGROUND_ORIGIN, "", "" );
+            createOU( repository, OU_NAME, OU_OWNER );
         }
-        
+
         configurationService.addConfiguration( getGlobalConfiguration() );
 
         // notify cluster service that bootstrap is completed to start synchronization

--- a/jbpm-wb-showcase/src/main/resources/org/jbpm/workbench/jBPMShowcase.gwt.xml
+++ b/jbpm-wb-showcase/src/main/resources/org/jbpm/workbench/jBPMShowcase.gwt.xml
@@ -46,6 +46,7 @@
   <inherits name="org.kie.workbench.common.screens.search.KieWorkbenchSearchScreenClient"/>
   <inherits name="org.kie.workbench.common.workbench.KieDefaultWorkbenchClient"/>
   <inherits name="org.kie.workbench.common.screens.library.LibraryClient"/>
+  <inherits name="org.kie.workbench.common.screens.examples.KieWorkbenchCommonExamplesClient"/>
 
   <inherits name="org.drools.workbench.screens.drltext.DroolsWorkbenchDRLTextEditorClient"/>
   <inherits name="org.drools.workbench.screens.workitems.DroolsWorkbenchWorkItemsEditorClient"/>


### PR DESCRIPTION
Remove repository initialization from AppSetup

The examples will be moved from https://github.com/droolsjbpm/jbpm-playground to https://github.com/droolsjbpm/kie-wb-playground. This might be a good place to discuss which examples should be included in the workbench by default.


