### PR TITLE
JBPM-5454 - KIE Server router - support for advanced queries and work…

### DIFF
--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/DashboardKpis.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/DashboardKpis.java
@@ -333,6 +333,7 @@ public class DashboardKpis {
                         .column(COLUMN_TASK_CREATED_DATE).format(i18n.taskTableStartDate(), DateUtils.getDateTimeFormatMask())
                         .column(COLUMN_TASK_END_DATE).format(i18n.taskTableEndDate(), DateUtils.getDateTimeFormatMask())
                         .column(COLUMN_TASK_DURATION).format(i18n.taskTableDuration())
+                        .column(COLUMN_PROCESS_EXTERNAL_ID).format(i18n.processTableDeploymentId())
                         .tablePageSize(10)
                         .tableOrderEnabled(true)
                         .tableOrderDefault(COLUMN_TASK_CREATED_DATE, DESCENDING)

--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/TaskDashboard.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/TaskDashboard.java
@@ -37,16 +37,17 @@ import org.dashbuilder.displayer.client.DisplayerListener;
 import org.dashbuilder.displayer.client.DisplayerLocator;
 import org.dashbuilder.renderer.client.metric.MetricDisplayer;
 import org.dashbuilder.renderer.client.table.TableDisplayer;
+
 import org.jboss.errai.common.client.api.Caller;
-import org.jbpm.workbench.pr.model.ProcessInstanceKey;
-import org.jbpm.workbench.pr.model.ProcessInstanceSummary;
-import org.jbpm.workbench.common.client.menu.ServerTemplateSelectorMenuBuilder;
-import org.jbpm.workbench.ht.model.events.TaskSelectionEvent;
-import org.jbpm.workbench.pr.service.ProcessRuntimeDataService;
 import org.jbpm.dashboard.renderer.client.panel.events.ProcessDashboardFocusEvent;
 import org.jbpm.dashboard.renderer.client.panel.events.TaskDashboardFocusEvent;
 import org.jbpm.dashboard.renderer.client.panel.formatter.DurationFormatter;
 import org.jbpm.dashboard.renderer.client.panel.widgets.ProcessBreadCrumb;
+import org.jbpm.workbench.common.client.menu.ServerTemplateSelectorMenuBuilder;
+import org.jbpm.workbench.ht.model.events.TaskSelectionEvent;
+import org.jbpm.workbench.pr.model.ProcessInstanceKey;
+import org.jbpm.workbench.pr.model.ProcessInstanceSummary;
+import org.jbpm.workbench.pr.service.ProcessRuntimeDataService;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.PlaceStatus;
 import org.uberfire.mvp.Command;
@@ -345,13 +346,14 @@ public class TaskDashboard extends AbstractDashboard implements IsWidget {
 
         final Long taskId = Double.valueOf(ds.getValueAt(rowIndex, COLUMN_TASK_ID).toString()).longValue();
         final String taskName = ds.getValueAt(rowIndex, COLUMN_TASK_NAME).toString();
+        final String deploymentId = ds.getValueAt(rowIndex, COLUMN_PROCESS_EXTERNAL_ID).toString();
         final Long processInstanceId = Double.valueOf(ds.getValueAt(rowIndex, COLUMN_PROCESS_INSTANCE_ID).toString()).longValue();
         final String serverTemplateId = serverTemplateSelectorMenuBuilder.getSelectedServerTemplate();
 
         processRuntimeDataService.call( (ProcessInstanceSummary p) -> {
                     openTaskDetailsScreen();
                     taskSelectionEvent.fire(new TaskSelectionEvent(serverTemplateId, p.getDeploymentId(), taskId, taskName, false, true));
-                }).getProcessInstance(serverTemplateId, new ProcessInstanceKey(serverTemplateId, processInstanceId));
+                }).getProcessInstance(serverTemplateId, new ProcessInstanceKey(serverTemplateId, deploymentId, processInstanceId));
     }
 
     public void showDashboard() {

--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/test/java/org/jbpm/dashboard/renderer/client/TaskDashboardData.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/test/java/org/jbpm/dashboard/renderer/client/TaskDashboardData.java
@@ -36,7 +36,8 @@ public class TaskDashboardData extends RawDataSet {
                     COLUMN_TASK_START_DATE.toUpperCase(),
                     COLUMN_TASK_END_DATE.toUpperCase(),
                     COLUMN_TASK_STATUS.toUpperCase(),
-                    COLUMN_TASK_DURATION.toUpperCase()},
+                    COLUMN_TASK_DURATION.toUpperCase(),
+                    COLUMN_PROCESS_EXTERNAL_ID.toUpperCase()},
             new Class[] {
                     String.class,
                     Integer.class,
@@ -47,17 +48,18 @@ public class TaskDashboardData extends RawDataSet {
                     Date.class,
                     Date.class,
                     String.class,
-                    Integer.class},
+                    Integer.class,
+                    String.class},
             new String[][] {
-                    {"Process A", "1", "1", "Task 1", "user1", "01/01/19 10:00", "01/01/19 12:00", null, TASK_STATUS_IN_PROGRESS, null},
-                    {"Process A", "1", "2", "Task 2", "user1", "01/01/19 09:00", "11/01/19 12:00", "01/01/19 13:00", TASK_STATUS_COMPLETED, "9000"},
-                    {"Process A", "1", "3", "Task 3", "user2", "01/01/19 08:00", "10/01/19 12:00", null, TASK_STATUS_SUSPENDED, null},
-                    {"Process A", "1", "4", "Task 4", "user2", "01/01/19 10:00", "09/01/19 12:00", null, TASK_STATUS_IN_PROGRESS, null},
-                    {"Process B", "2", "5", "Task 2", "user1", "01/01/19 06:00", "08/01/19 12:00", null, TASK_STATUS_IN_PROGRESS, null},
-                    {"Process B", "2", "6", "Task 2", "user3", "01/01/19 07:00", "07/01/19 12:00", null, TASK_STATUS_ERROR, null},
-                    {"Process B", "2", "7", "Task 3", "user4", "01/01/19 08:00", "05/01/19 12:00", null, TASK_STATUS_RESERVED, null},
-                    {"Process B", "2", "8", "Task 4", "user4", "01/01/19 10:00", "05/11/19 12:00", "12/02/19 16:00", TASK_STATUS_COMPLETED, "10000"},
-                    {"Process B", "2", "9", "Task 4", "user4", "01/01/19 10:00", "05/11/19 12:00", null, TASK_STATUS_EXITED, null}
+                    {"Process A", "1", "1", "Task 1", "user1", "01/01/19 10:00", "01/01/19 12:00", null, TASK_STATUS_IN_PROGRESS, null, "deploymentId"},
+                    {"Process A", "1", "2", "Task 2", "user1", "01/01/19 09:00", "11/01/19 12:00", "01/01/19 13:00", TASK_STATUS_COMPLETED, "9000", "deploymentId"},
+                    {"Process A", "1", "3", "Task 3", "user2", "01/01/19 08:00", "10/01/19 12:00", null, TASK_STATUS_SUSPENDED, null, "deploymentId"},
+                    {"Process A", "1", "4", "Task 4", "user2", "01/01/19 10:00", "09/01/19 12:00", null, TASK_STATUS_IN_PROGRESS, null, "deploymentId"},
+                    {"Process B", "2", "5", "Task 2", "user1", "01/01/19 06:00", "08/01/19 12:00", null, TASK_STATUS_IN_PROGRESS, null, "deploymentId"},
+                    {"Process B", "2", "6", "Task 2", "user3", "01/01/19 07:00", "07/01/19 12:00", null, TASK_STATUS_ERROR, null, "deploymentId"},
+                    {"Process B", "2", "7", "Task 3", "user4", "01/01/19 08:00", "05/01/19 12:00", null, TASK_STATUS_RESERVED, null, "deploymentId"},
+                    {"Process B", "2", "8", "Task 4", "user4", "01/01/19 10:00", "05/11/19 12:00", "12/02/19 16:00", TASK_STATUS_COMPLETED, "10000", "deploymentId"},
+                    {"Process B", "2", "9", "Task 4", "user4", "01/01/19 10:00", "05/11/19 12:00", null, TASK_STATUS_EXITED, null, "deploymentId"}
             });
 
     public TaskDashboardData(String[] columnIds, Class[] types, String[][] data) {

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-backend/src/main/java/org/jbpm/workbench/ht/backend/server/RemoteTaskServiceImpl.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-backend/src/main/java/org/jbpm/workbench/ht/backend/server/RemoteTaskServiceImpl.java
@@ -187,7 +187,7 @@ public class RemoteTaskServiceImpl extends AbstractKieServerService implements T
 
         UserTaskServicesClient client = getClient(serverTemplateId, UserTaskServicesClient.class);
 
-        List<TaskEventInstance> events = client.findTaskEvents(taskId, 0, 1000);
+        List<TaskEventInstance> events = client.findTaskEvents(containerId, taskId, 0, 1000);
 
         return events.stream().map(e -> build(e)).collect(toList());
     }

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/editors/taskprocesscontext/TaskProcessContextPresenter.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/editors/taskprocesscontext/TaskProcessContextPresenter.java
@@ -115,7 +115,7 @@ public class TaskProcessContextPresenter {
                                   );
                               }
                           }
-        ).getProcessInstance(serverTemplateId, new ProcessInstanceKey(serverTemplateId, currentProcessInstanceId));
+        ).getProcessInstance(serverTemplateId, new ProcessInstanceKey(serverTemplateId, containerId, currentProcessInstanceId));
     }
 
     public void refreshProcessContextOfTask() {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/model/ProcessInstanceKey.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/model/ProcessInstanceKey.java
@@ -23,13 +23,15 @@ import org.jbpm.workbench.common.service.ItemKey;
 public class ProcessInstanceKey implements ItemKey {
 
     private String serverTemplateId;
+    private String deploymentId;
     private Long processInstanceId;
 
     public ProcessInstanceKey() {
     }
 
-    public ProcessInstanceKey(String serverTemplateId, Long processInstanceId) {
+    public ProcessInstanceKey(String serverTemplateId, String deploymentId, Long processInstanceId) {
         this.serverTemplateId = serverTemplateId;
+        this.deploymentId = deploymentId;
         this.processInstanceId = processInstanceId;
     }
 
@@ -41,11 +43,17 @@ public class ProcessInstanceKey implements ItemKey {
         return serverTemplateId;
     }
 
+    public String getDeploymentId() {
+        return deploymentId;
+    }
+
     @Override
     @SuppressWarnings("PMD.AvoidMultipleUnaryOperators")
     public int hashCode() {
         int hash = 7;
         hash = 13 * hash + (this.serverTemplateId != null ? this.serverTemplateId.hashCode() : 0);
+        hash = ~~hash;
+        hash = 13 * hash + (this.deploymentId != null ? this.deploymentId.hashCode() : 0);
         hash = ~~hash;
         hash = 13 * hash + (this.processInstanceId != null ? this.processInstanceId.hashCode() : 0);
         hash = ~~hash;
@@ -62,6 +70,9 @@ public class ProcessInstanceKey implements ItemKey {
         }
         final ProcessInstanceKey other = (ProcessInstanceKey) obj;
         if (this.serverTemplateId != other.serverTemplateId && (this.serverTemplateId == null || !this.serverTemplateId.equals(other.serverTemplateId))) {
+            return false;
+        }
+        if (this.deploymentId != other.deploymentId && (this.deploymentId == null || !this.deploymentId.equals(other.deploymentId))) {
             return false;
         }
         if (this.processInstanceId != other.processInstanceId && (this.processInstanceId == null || !this.processInstanceId.equals(other.processInstanceId))) {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/service/ProcessRuntimeDataService.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/service/ProcessRuntimeDataService.java
@@ -34,11 +34,11 @@ public interface ProcessRuntimeDataService {
 
     ProcessInstanceSummary getProcessInstance(String serverTemplateId, ProcessInstanceKey processInstanceKey);
 
-    List<NodeInstanceSummary> getProcessInstanceActiveNodes(String serverTemplateId, Long processInstanceId);
+    List<NodeInstanceSummary> getProcessInstanceActiveNodes(String serverTemplateId, String deploymentId, Long processInstanceId);
 
-    List<RuntimeLogSummary> getRuntimeLogs(String serverTemplateId, Long processInstanceId);
+    List<RuntimeLogSummary> getRuntimeLogs(String serverTemplateId, String deploymentId, Long processInstanceId);
 
-    List<RuntimeLogSummary> getBusinessLogs(String serverTemplateId, String processName, Long processInstanceId);
+    List<RuntimeLogSummary> getBusinessLogs(String serverTemplateId, String deploymentId, String processName, Long processInstanceId);
 
     List<ProcessSummary> getProcesses(String serverTemplateId, Integer page, Integer pageSize, String sort, Boolean sortOrder);
 

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
@@ -69,23 +69,23 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
             return null;
         }
 
-        QueryServicesClient queryServicesClient = getClient(serverTemplateId, QueryServicesClient.class);
+        ProcessServicesClient queryServicesClient = getClient(serverTemplateId, ProcessServicesClient.class);
 
-        ProcessInstance processInstance = queryServicesClient.findProcessInstanceById(processInstanceKey.getProcessInstanceId());
+        ProcessInstance processInstance = queryServicesClient.getProcessInstance(processInstanceKey.getDeploymentId(), processInstanceKey.getProcessInstanceId());
 
         return build(processInstance);
     }
 
     @Override
-    public List<NodeInstanceSummary> getProcessInstanceActiveNodes(String serverTemplateId, Long processInstanceId) {
+    public List<NodeInstanceSummary> getProcessInstanceActiveNodes(String serverTemplateId, String deploymentId, Long processInstanceId) {
         if (serverTemplateId == null || serverTemplateId.isEmpty()) {
             return emptyList();
         }
 
         List<NodeInstanceSummary> instances = new ArrayList<NodeInstanceSummary>();
-        QueryServicesClient queryServicesClient = getClient(serverTemplateId, QueryServicesClient.class);
+        ProcessServicesClient processServicesClient = getClient(serverTemplateId, ProcessServicesClient.class);
 
-        List<NodeInstance> nodeInstances = queryServicesClient.findActiveNodeInstances(processInstanceId, 0, 100);
+        List<NodeInstance> nodeInstances = processServicesClient.findActiveNodeInstances(deploymentId, processInstanceId, 0, 100);
 
         for (NodeInstance instance : nodeInstances) {
             NodeInstanceSummary summary = new NodeInstanceSummary(instance.getId(),
@@ -104,12 +104,12 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
     }
 
     @Override
-    public List<RuntimeLogSummary> getBusinessLogs(String serverTemplateId, String processName, Long processInstanceId) {
+    public List<RuntimeLogSummary> getBusinessLogs(String serverTemplateId, String deploymentId, String processName, Long processInstanceId) {
         if (serverTemplateId == null || serverTemplateId.isEmpty()) {
             return emptyList();
         }
 
-        List<NodeInstance> processInstanceHistory = getProcessInstanceHistory(serverTemplateId, processInstanceId);
+        List<NodeInstance> processInstanceHistory = getProcessInstanceHistory(serverTemplateId, deploymentId, processInstanceId);
         List<TaskEventInstance> allTaskEventsByProcessInstanceId = new ArrayList<TaskEventInstance>();//taskAuditService.getAllTaskEventsByProcessInstanceId(processInstanceId, "");
         List<RuntimeLogSummary> logs = new ArrayList<RuntimeLogSummary>(processInstanceHistory.size() + allTaskEventsByProcessInstanceId.size());
         PrettyTime prettyDateFormatter = new PrettyTime();
@@ -251,12 +251,12 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
     }
 
     @Override
-    public List<RuntimeLogSummary> getRuntimeLogs(final String serverTemplateId, final Long processInstanceId) {
+    public List<RuntimeLogSummary> getRuntimeLogs(final String serverTemplateId, String deploymentId, final Long processInstanceId) {
         if (serverTemplateId == null || serverTemplateId.isEmpty()) {
             return emptyList();
         }
 
-        List<NodeInstance> processInstanceHistory = getProcessInstanceHistory(serverTemplateId, processInstanceId);
+        List<NodeInstance> processInstanceHistory = getProcessInstanceHistory(serverTemplateId, deploymentId, processInstanceId);
         List<TaskEventInstance> allTaskEventsByProcessInstanceId = new ArrayList<TaskEventInstance>();//taskAuditService.getAllTaskEventsByProcessInstanceId(processInstanceId, "");
         List<RuntimeLogSummary> logs = new ArrayList<RuntimeLogSummary>(processInstanceHistory.size() + allTaskEventsByProcessInstanceId.size());
         PrettyTime prettyDateFormatter = new PrettyTime();
@@ -285,14 +285,14 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
         return logs;
     }
 
-    protected List<NodeInstance> getProcessInstanceHistory(final String serverTemplateId, final Long processInstanceId) {
+    protected List<NodeInstance> getProcessInstanceHistory(final String serverTemplateId, String deploymentId, final Long processInstanceId) {
         if (serverTemplateId == null || serverTemplateId.isEmpty()) {
             return emptyList();
         }
 
-        QueryServicesClient queryServicesClient = getClient(serverTemplateId, QueryServicesClient.class);
+        ProcessServicesClient processServicesClient = getClient(serverTemplateId, ProcessServicesClient.class);
 
-        return queryServicesClient.findNodeInstances(processInstanceId, 0, 100);
+        return processServicesClient.findNodeInstances(deploymentId, processInstanceId, 0, 100);
 
     }
 

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessVariablesServiceImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessVariablesServiceImpl.java
@@ -31,7 +31,6 @@ import org.jbpm.workbench.pr.service.ProcessVariablesService;
 import org.kie.server.api.model.definition.VariablesDefinition;
 import org.kie.server.api.model.instance.VariableInstance;
 import org.kie.server.client.ProcessServicesClient;
-import org.kie.server.client.QueryServicesClient;
 import org.uberfire.paging.PageResponse;
 
 @Service
@@ -83,13 +82,12 @@ public class RemoteProcessVariablesServiceImpl extends AbstractKieServerService 
 
         Map<String, String> properties = new HashMap<String, String>();
 
-        QueryServicesClient queryClient = getClient(serverTemplateId, QueryServicesClient.class);
         ProcessServicesClient processClient = getClient(serverTemplateId, ProcessServicesClient.class);
 
         VariablesDefinition vars = processClient.getProcessVariableDefinitions(deploymentId, processId);
         properties.putAll(vars.getVariables());
 
-        List<VariableInstance> variables = queryClient.findVariablesCurrentState(processInstanceId);
+        List<VariableInstance> variables = processClient.findVariablesCurrentState(deploymentId, processInstanceId);
 
         Collection<ProcessVariableSummary> processVariables = VariableHelper.adaptCollection(variables, properties, processInstanceId, deploymentId, serverTemplateId);
 
@@ -107,9 +105,8 @@ public class RemoteProcessVariablesServiceImpl extends AbstractKieServerService 
 
     @Override
     public List<ProcessVariableSummary> getVariableHistory(String serverTemplateId, String deploymentId, Long processInstanceId, String variableName) {
-        QueryServicesClient queryClient = getClient(serverTemplateId, QueryServicesClient.class);
-
-        List<VariableInstance> variables = queryClient.findVariableHistory(processInstanceId, variableName, 0, 100);
+        ProcessServicesClient processClient = getClient(serverTemplateId, ProcessServicesClient.class);
+        List<VariableInstance> variables = processClient.findVariableHistory(deploymentId, processInstanceId, variableName, 0, 100);
 
         return VariableHelper.adaptCollection(variables, new HashMap<String, String>(), processInstanceId, deploymentId, serverTemplateId);
     }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsPresenter.java
@@ -162,7 +162,7 @@ public class ProcessInstanceDetailsPresenter {
                         processSelected.getStartTime() );
 
             }
-        } ).getProcessInstance(serverTemplateId, new ProcessInstanceKey(serverTemplateId, Long.parseLong(processId)));
+        } ).getProcessInstance(serverTemplateId, new ProcessInstanceKey(serverTemplateId, deploymentId, Long.parseLong(processId)));
 
 
         processRuntimeDataService.call(new RemoteCallback<List<NodeInstanceSummary>>() {
@@ -175,7 +175,7 @@ public class ProcessInstanceDetailsPresenter {
                 }
                 view.getCurrentActivitiesListBox().setHTML( safeHtmlBuilder.toSafeHtml() );
             }
-        } ).getProcessInstanceActiveNodes( serverTemplateId, Long.parseLong( processId ) );
+        } ).getProcessInstanceActiveNodes( serverTemplateId, deploymentId, Long.parseLong( processId ) );
     }
 
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/log/RuntimeLogPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/log/RuntimeLogPresenter.java
@@ -39,6 +39,7 @@ public class RuntimeLogPresenter {
     private Long currentProcessInstanceId;
     private String currentProcessName;
     private String currentServerTemplateId;
+    private String currentDeploymentId;
 
     public interface RuntimeLogView extends IsWidget {
 
@@ -81,7 +82,7 @@ public class RuntimeLogPresenter {
 
                     view.setLogs( logsLine );
                 }
-            } ).getRuntimeLogs(currentServerTemplateId, currentProcessInstanceId);
+            } ).getRuntimeLogs(currentServerTemplateId, currentDeploymentId, currentProcessInstanceId);
         } else {
             processRuntimeDataService.call(new RemoteCallback<List<RuntimeLogSummary>>() {
                 @Override
@@ -97,7 +98,7 @@ public class RuntimeLogPresenter {
 
                     view.setLogs( logsLine );
                 }
-            } ).getBusinessLogs(currentServerTemplateId, currentProcessName, currentProcessInstanceId );
+            } ).getBusinessLogs(currentServerTemplateId, currentDeploymentId, currentProcessName, currentProcessInstanceId );
         }
     }
 
@@ -105,6 +106,7 @@ public class RuntimeLogPresenter {
         this.currentProcessInstanceId = event.getProcessInstanceId();
         this.currentProcessName = event.getProcessDefName();
         this.currentServerTemplateId = event.getServerTemplateId();
+        this.currentDeploymentId = event.getDeploymentId();
 
         refreshProcessInstanceData( LogOrder.ASC, LogType.BUSINESS );
     }


### PR DESCRIPTION
…bench integration

depends on https://github.com/droolsjbpm/droolsjbpm-integration/pull/795

this is in general to be able to use KIE Server router with workbench for basic operations via UI. Overall changes are to switch to KIE Server client operations that include container id so router can efficiently find the right kie server instead of collecting and aggregating data for single instance operations like getProcessInstance or getTaskEvents.
